### PR TITLE
fix(sync): align fakerpress with EasyCommerce model layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,8 @@
 - **WordPress Comments Integration**: Leverages WordPress comment system for review storage
 - **Verified Purchase Tracking**: Reviews can be marked as verified purchases for enhanced credibility
 - **Order Generator Data Structure Fix**: Corrected Order generator to match EasyCommerce Order model expectations
-- **Order Notes Integration**: Added proper order notes creation using Order_Notes model
-- **Comprehensive Model Review**: Validated all 11 EasyCommerce models for proper generator integration
+- **Order Notes**: Notes stored via order meta (`Order::create()` meta array); EC has no `Order_Notes` model
+- **EC Model Coverage**: Fakerpress covers 11 generator-relevant EC models; `Abandoned_Cart`, `Order_Item`, `Order_Item_Meta`, `Order_Meta`, `Product_Meta`, and variation sub-models are handled internally by EC's own model layer — no separate generator needed
 - **Controller Pattern Alignment**: Updated Product_Review controller to match existing controller patterns
 - **Complete Model Validation**: Validated all generators against EasyCommerce models for data consistency
 - **API Schema Consistency**: Added proper resource-specific properties and parameter validation
@@ -108,7 +108,7 @@
 - **Model Integration**: Always use appropriate EasyCommerce model classes for data creation
 - **Data Structure Alignment**: Ensure generator `create()` calls match EasyCommerce model expectations exactly
 - **Meta Data Handling**: Use meta arrays for additional data not handled by base model properties
-- **Related Model Usage**: Implement proper relationships using dedicated models (e.g., Order_Notes for order comments)
+- **Related Model Usage**: Use EC model methods where they exist; fall back to direct meta storage when EC has no dedicated model (e.g., order notes — EC has no `Order_Notes` model, so notes are stored via `Order::add_meta()` / the meta array passed to `Order::create()`)
 - **Parameter Dependencies**: Use `dependsOn` in React parameter configs for conditional fields
 - **API Endpoint Naming**: REST bases should be plural (e.g., `orders`, `products`, `customers`)
 - **Result Formatting**: Return consistent result arrays with `id`, `message`, and relevant metadata

--- a/includes/Generators/Order.php
+++ b/includes/Generators/Order.php
@@ -215,11 +215,6 @@ class Order extends Generator {
 			return new WP_Error( 'order_creation_failed', __( 'Failed to create order using EasyCommerce model.', 'easycommerce-fakerpress' ) );
 		}
 
-		// Create order notes if they exist.
-		if ( ! empty( $complete_meta['notes'] ) ) {
-			$this->create_order_notes( $order->get_id(), $complete_meta['notes'] );
-		}
-
 		// Update customer statistics.
 		$this->update_customer_stats( $customer['id'], $total );
 
@@ -1106,34 +1101,6 @@ class Order extends Generator {
 		$current_points = (int) get_user_meta( $customer_id, 'loyalty_points', true );
 		$points_earned  = floor( $order_total );
 		update_user_meta( $customer_id, 'loyalty_points', $current_points + $points_earned );
-	}
-
-	/**
-	 * Create order notes for the order.
-	 *
-	 * @since 2.0.4
-	 *
-	 * @param int   $order_id Order ID.
-	 * @param array $notes    Array of note data.
-	 *
-	 * @return void
-	 */
-	private function create_order_notes( int $order_id, array $notes ): void {
-		if ( ! class_exists( 'EasyCommerce\\Models\\Order_Notes' ) ) {
-			return;
-		}
-
-		$order_notes_model = new \EasyCommerce\Models\Order_Notes();
-
-		foreach ( $notes as $note ) {
-			if ( is_array( $note ) && isset( $note['note'] ) ) {
-				$order_notes_model->add(
-					$order_id,
-					isset( $note['type'] ) ? $note['type'] : 'customer',
-					$note['note']
-				);
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **fix**: Remove dead `Order_Notes` reference in Order generator — `EasyCommerce\Models\Order_Notes` does not exist in EC; the `class_exists` guard caused silent no-op on every generation. Order notes are already persisted via the `meta` array passed to `Order::create()` (stored in `order_meta` table), so no data is lost.
- **docs**: Update `AGENTS.md` to accurately document EC model coverage, order notes approach, and clarify that `Abandoned_Cart`, `Order_Item*`, `Product_Meta`, and variation sub-models are handled internally by EC's own model layer.

## Root cause

EC has no `Order_Notes` model, no `order_notes` table. The generator referenced a model that was never implemented. The `class_exists` guard prevented a fatal error but silently skipped note creation on every run. Notes were already stored in `order_meta` via `Order::create()`.

## EC model sync audit (from this investigation)

| Model | Status |
|-------|--------|
| Order — items format `[product_id][price_id]` | ✅ correct |
| Cart — `total` column (recently added) | ✅ already set |
| Product_Review — no EC `create()` method | ✅ correctly uses `wp_insert_comment()` |
| Tax — `create_class()` method | ✅ still exists |
| Order_Notes | ❌ model does not exist in EC → fixed |
| Abandoned_Cart | ℹ️ read-only list model, no generator needed |

## Test plan

- [ ] Generate orders — confirm no PHP errors
- [ ] Verify order notes still appear in `order_meta` table under `notes` key
- [ ] Run `composer phpcs` — pre-existing lint error in `class-easycommerce-fakerpress.php:791` unrelated to this diff