### PR TITLE
fix(generators): align generated statuses with core DB ENUMs + harden

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,14 +37,14 @@ composer release    # lint + analyse + build + makepot + zip into release/
 - `includes/` — PSR-4 namespace root `EasyCommerceFakerPress\`
   - `Abstracts/Generator.php` — base for all generators (FakerPHP wiring, Template Method pattern, logging, batch processing)
   - `Abstracts/Controller.php` — base for all REST controllers (extends `WP_REST_Controller`, namespace `easycommerce-fakerpress/v1`)
-  - `Generators/` — 11 concrete generators (Product, Customer, Order, Coupon, Product_Variation, Shipping_Plan, Tax_Class, Transaction, Cart_Session, Location, Product_Review)
+  - `Generators/` — 14 concrete generators (Product, Customer, Order, Coupon, Product_Variation, Shipping_Plan, Tax_Class, Transaction, Cart_Session, Location, Product_Review, Attribute, Refund, Log)
   - `Controllers/` — matching REST controllers, one per generator; REST base is the plural resource name
   - `MCP/MCP_Server.php` + `MCP/Abilities/` — MCP tool registration (requires mcp-adapter plugin)
 
 ### Data flow
 ```
 React component → REST POST /easycommerce-fakerpress/v1/{resource}/generate
-  → Controller::generate() validates params
+  → Controller::generate_items() validates params
   → Generator::generate() uses FakerPHP + EasyCommerce models
   → returns { id, message, metadata }
 ```
@@ -52,7 +52,8 @@ React component → REST POST /easycommerce-fakerpress/v1/{resource}/generate
 ### React/JS layer
 - `src/admin/components/App.tsx` — React Router v7 root
 - `src/admin/components/Pages/` — `HomePage`, `GeneratorPage`, `RootLayout`
-- `src/admin/components/Generators/` — one component per generator (extends `GeneratorBase.tsx`)
+- `src/admin/components/generator/` — shared schema-driven UI (`ConfigColumn.tsx`, `RunBar.tsx`, `PreviewTable.tsx`); there is **no** per-generator component file
+- `src/admin/lib/generators.ts` — single config array describing all 14 generators (drives the UI)
 - `src/admin/components/ui/` — Radix UI primitives wrapped with Tailwind + CVA
 - `@` path alias resolves to `src/`
 - WordPress admin colors injected as CSS vars (`--wp-admin-primary` etc.) and passed via `window.easycommerceFakerpressApi`
@@ -61,5 +62,5 @@ React component → REST POST /easycommerce-fakerpress/v1/{resource}/generate
 - PHP: WordPress coding standards, camelCase methods, snake_case file names
 - JS: TypeScript strict, functional components + hooks only, Tailwind v4 (`@theme`/`@utility` directives)
 - REST: plural endpoint bases (`products`, `orders`); params validated via JSON Schema in controller `get_params()`
-- Adding a generator requires: new `Generators/Foo.php`, new `Controllers/Foo.php`, new `src/admin/components/Generators/FooGenerator.tsx`, register controller in `class-easycommerce-fakerpress.php::register_rest_routes()`
+- Adding a generator requires: new `includes/Generators/Foo.php`, new `includes/Controllers/Foo.php`, a config entry in `src/admin/lib/generators.ts`, and registering the controller in `class-easycommerce-fakerpress.php::register_rest_routes()`
 - Plugin requires EasyCommerce to be active; all REST routes and the admin menu are gated behind `check_dependencies()`

--- a/class-easycommerce-fakerpress.php
+++ b/class-easycommerce-fakerpress.php
@@ -50,7 +50,7 @@ use EasyCommerceFakerPress\MCP\MCP_Server;
  * - Multi-locale support for international data generation
  *
  * @since 1.0.0
- * @version 2.0.3
+ * @version 2.2.0
  */
 class EasyCommerce_FakerPress {
 
@@ -628,6 +628,16 @@ class EasyCommerce_FakerPress {
 			return false;
 		}
 
+		// Guard against zip-slip: reject any entry that escapes the target dir.
+		for ( $i = 0; $i < $zip->numFiles; $i++ ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- ZipArchive built-in property.
+			$entry_name = $zip->getNameIndex( $i );
+			if ( false === $entry_name || 0 === strpos( $entry_name, '/' ) || false !== strpos( $entry_name, '..' ) ) {
+				error_log( 'EasyCommerce FakerPress: Unsafe path in zip archive: ' . $entry_name ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				$zip->close();
+				return false;
+			}
+		}
+
 		if ( ! $zip->extractTo( $extract_to ) ) {
 			error_log( 'EasyCommerce FakerPress: Failed to extract zip file' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			$zip->close();
@@ -732,6 +742,12 @@ class EasyCommerce_FakerPress {
 	 * @return bool True if EasyCommerce is active, false otherwise.
 	 */
 	public function is_easycommerce_active(): bool {
+		// is_plugin_active() lives in wp-admin/includes/plugin.php, which is not
+		// loaded on front-end / REST requests — require it before use.
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		return is_plugin_active( 'easycommerce/easycommerce.php' );
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "mralaminahamed/easycommerce-fakerpress",
-    "description": "Comprehensive EasyCommerce test data generator with 11 specialized generators, real-time validation, advanced parameter configuration, WordPress admin color integration, and modern React Router v7 interface.",
+    "description": "Comprehensive EasyCommerce test data generator with 14 specialized generators, real-time validation, advanced parameter configuration, WordPress admin color integration, and modern React Router v7 interface.",
     "license": "GPL-2.0-or-later",
     "type": "wordpress-plugin",
     "authors": [

--- a/includes/Abstracts/Controller.php
+++ b/includes/Abstracts/Controller.php
@@ -12,6 +12,8 @@
 
 namespace EasyCommerceFakerPress\Abstracts;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use WP_REST_Controller;
 use WP_REST_Request;
 use WP_REST_Response;

--- a/includes/Abstracts/Generator.php
+++ b/includes/Abstracts/Generator.php
@@ -13,6 +13,8 @@
 
 namespace EasyCommerceFakerPress\Abstracts;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use Bluemmb\Faker\PicsumPhotosProvider;
 use Exception;
 use Faker\Factory;

--- a/includes/Controllers/Attribute.php
+++ b/includes/Controllers/Attribute.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Attribute as AttributeGenerator;
 

--- a/includes/Controllers/Cart_Session.php
+++ b/includes/Controllers/Cart_Session.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Cart_Session as CartSessionGenerator;
 

--- a/includes/Controllers/Coupon.php
+++ b/includes/Controllers/Coupon.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Coupon as CouponGenerator;
 

--- a/includes/Controllers/Customer.php
+++ b/includes/Controllers/Customer.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Customer as CustomerGenerator;
 

--- a/includes/Controllers/Location.php
+++ b/includes/Controllers/Location.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Location as LocationGenerator;
 

--- a/includes/Controllers/Log.php
+++ b/includes/Controllers/Log.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Log as LogGenerator;
 

--- a/includes/Controllers/Order.php
+++ b/includes/Controllers/Order.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Order as OrderGenerator;
 

--- a/includes/Controllers/Product.php
+++ b/includes/Controllers/Product.php
@@ -11,6 +11,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Product as ProductGenerator;
 

--- a/includes/Controllers/Product_Review.php
+++ b/includes/Controllers/Product_Review.php
@@ -11,6 +11,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Product_Review as ProductReviewGenerator;
 

--- a/includes/Controllers/Product_Variation.php
+++ b/includes/Controllers/Product_Variation.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Product_Variation as ProductVariationGenerator;
 

--- a/includes/Controllers/Refund.php
+++ b/includes/Controllers/Refund.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Refund as RefundGenerator;
 

--- a/includes/Controllers/Shipping_Plan.php
+++ b/includes/Controllers/Shipping_Plan.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Shipping_Plan as ShippingPlanGenerator;
 

--- a/includes/Controllers/Tax_Class.php
+++ b/includes/Controllers/Tax_Class.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Tax_Class as TaxClassGenerator;
 

--- a/includes/Controllers/Transaction.php
+++ b/includes/Controllers/Transaction.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Controllers;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Controller;
 use EasyCommerceFakerPress\Generators\Transaction as TransactionGenerator;
 

--- a/includes/Generators/Attribute.php
+++ b/includes/Generators/Attribute.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Generators;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Generator;
 use EasyCommerce\Models\Attribute as AttributeModel;
 use EasyCommerce\Models\Attribute_Value as AttributeValueModel;

--- a/includes/Generators/Coupon.php
+++ b/includes/Generators/Coupon.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Generators;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Generator;
 use EasyCommerce\Models\Coupon as CouponModel;
 use EasyCommerce\Models\Database;

--- a/includes/Generators/Customer.php
+++ b/includes/Generators/Customer.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Generators;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Generator;
 use EasyCommerce\Models\Customer as CustomerModel;
 use WP_Error;

--- a/includes/Generators/Location.php
+++ b/includes/Generators/Location.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Generators;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Generator;
 use EasyCommerce\Models\Location as LocationModel;
 use WP_Error;

--- a/includes/Generators/Log.php
+++ b/includes/Generators/Log.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Generators;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerce\Models\Log as LogModel;
 use EasyCommerceFakerPress\Abstracts\Generator;
 use WP_Error;

--- a/includes/Generators/Order.php
+++ b/includes/Generators/Order.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Generators;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Generator;
 use EasyCommerce\Models\Order as OrderModel;
 use EasyCommerce\Models\Customer as CustomerModel;
@@ -220,7 +222,7 @@ class Order extends Generator {
 
 		$result = array(
 			'id'               => $order->get_id(),
-			'order_number'     => $order->get_order_number() ? $order->get_order_number() : 'ORD-' . $order->get_id(),
+			'order_number'     => 'ORD-' . $order->get_id(),
 			'customer_id'      => $customer['id'],
 			'status'           => $order->get_status(),
 			'total'            => $total,
@@ -492,7 +494,9 @@ class Order extends Generator {
 		// Get a larger pool of available variations to choose from.
 		$db              = new Database( 'product_variations' );
 		$variations_data = $db->get_rows(
-			array( 'status' => 'active' ),
+			// Purchasable variations. The product_variations.status ENUM is
+			// in_stock|out_of_stock|backorder|discontinued — there is no 'active'.
+			array( array( 'status' => array( 'IN', array( 'in_stock', 'backorder' ) ) ) ),
 			100, // Get more variations for better randomization.
 			0,
 			'RAND()'
@@ -897,7 +901,6 @@ class Order extends Generator {
 			'shipped'             => 20,
 			'delivered'           => 10,
 			'returned'            => 3,
-			'cancelled'           => 2,
 		);
 
 		$pool = array();

--- a/includes/Generators/Product.php
+++ b/includes/Generators/Product.php
@@ -12,6 +12,8 @@
 
 namespace EasyCommerceFakerPress\Generators;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerce\Models\Product as ProductModel;
 use EasyCommerce\Models\Attribute as AttributeModel;
 use EasyCommerce\Models\Attribute_Value as AttributeValueModel;
@@ -916,7 +918,8 @@ class Product extends Generator {
 		}
 
 		if ( $stock_quantity > 0 ) {
-			return $this->get_faker()->randomElement( array( 'in_stock', 'low_stock', 'backorder' ) );
+			// product_variations.status ENUM has no 'low_stock'.
+			return $this->get_faker()->randomElement( array( 'in_stock', 'backorder' ) );
 		}
 
 		return 'out_of_stock';

--- a/includes/Generators/Product_Review.php
+++ b/includes/Generators/Product_Review.php
@@ -11,6 +11,8 @@
 
 namespace EasyCommerceFakerPress\Generators;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerceFakerPress\Abstracts\Generator;
 use WP_Error;
 

--- a/includes/Generators/Product_Variation.php
+++ b/includes/Generators/Product_Variation.php
@@ -259,7 +259,7 @@ class Product_Variation extends Generator {
 			'sku'            => $this->generate_variation_sku( $product->get_slug(), $variation_attributes ),
 			'stock_quantity' => $this->get_faker()->numberBetween( 0, 100 ),
 			'stock_limit'    => $this->get_faker()->numberBetween( 5, 20 ),
-			'status'         => $this->get_faker()->randomElement( array( 'active', 'inactive', 'draft' ) ),
+			'status'         => $this->get_faker()->randomElement( array( 'in_stock', 'out_of_stock', 'backorder', 'discontinued' ) ),
 			'attributes'     => $variation_attributes,
 		);
 	}

--- a/includes/Generators/Refund.php
+++ b/includes/Generators/Refund.php
@@ -8,6 +8,8 @@
 
 namespace EasyCommerceFakerPress\Generators;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 use EasyCommerce\Models\Order as OrderModel;
 use EasyCommerce\Models\Refund as RefundModel;
 use EasyCommerceFakerPress\Abstracts\Generator;
@@ -120,11 +122,12 @@ class Refund extends Generator {
 			$amount = round( $total * $this->get_faker()->randomFloat( 2, 0.1, 0.9 ), 2 );
 		}
 
-		$gateway         = $this->get_faker()->randomElement(
+		$gateway = $this->get_faker()->randomElement(
 			$this->generation_params['payment_gateways'] ?? self::GATEWAYS
 		);
+		// refunds.status ENUM is pending|approved|processed|rejected — weight toward processed.
 		$status          = $this->get_faker()->randomElement(
-			array( 'completed', 'completed', 'pending', 'failed' )
+			array( 'processed', 'processed', 'approved', 'pending', 'rejected' )
 		);
 		$transaction_id  = $this->generate_transaction_id( $gateway );
 		$reason          = $this->get_faker()->randomElement( self::REASONS );

--- a/includes/Generators/Transaction.php
+++ b/includes/Generators/Transaction.php
@@ -2,9 +2,8 @@
 /**
  * Transaction Generator Class for EasyCommerce FakerPress Plugin
  *
- * @since 1.0.0
- * @subpackage Generators
- * @package EasyCommerceFakerPress
+ * @since   1.0.0
+ * @package EasyCommerceFakerPress\Generators
  */
 
 namespace EasyCommerceFakerPress\Generators;
@@ -185,7 +184,8 @@ class Transaction extends Generator {
 	 * @return array Transaction data
 	 */
 	private function generate_transaction_data( $order ): array {
-		$transaction_types = array( 'payment', 'refund', 'adjustment', 'fee', 'commission' );
+		// transactions.type ENUM is payment|refund|adjustment only.
+		$transaction_types = array( 'payment', 'refund', 'adjustment' );
 		$transaction_type  = $this->get_faker()->randomElement( $transaction_types );
 
 		$payment_gateways = array(
@@ -267,11 +267,12 @@ class Transaction extends Generator {
 	 */
 	private function generate_transaction_status( string $type ): string {
 		$status_weights = array(
+			// transactions.status ENUM is pending|completed|failed|refunded.
 			'payment'    => array(
 				'completed' => 70,
 				'pending'   => 15,
 				'failed'    => 10,
-				'cancelled' => 5,
+				'refunded'  => 5,
 			),
 			'refund'     => array(
 				'completed' => 80,
@@ -281,14 +282,6 @@ class Transaction extends Generator {
 			'adjustment' => array(
 				'completed' => 90,
 				'pending'   => 10,
-			),
-			'fee'        => array(
-				'completed' => 95,
-				'pending'   => 5,
-			),
-			'commission' => array(
-				'completed' => 85,
-				'pending'   => 15,
 			),
 		);
 

--- a/languages/easycommerce-fakerpress.pot
+++ b/languages/easycommerce-fakerpress.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: EasyCommerce FakerPress 2.0.4\n"
+"Project-Id-Version: EasyCommerce FakerPress 2.2.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/easycommerce-fakerpress\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=18.0.0",
     "yarn": ">=1.22.0"
   },
-  "description": "Comprehensive EasyCommerce test data generator with 11 specialized generators, real-time validation, advanced parameter configuration, WordPress admin color integration, and modern React Router v7 interface.",
+  "description": "Comprehensive EasyCommerce test data generator with 14 specialized generators, real-time validation, advanced parameter configuration, WordPress admin color integration, and modern React Router v7 interface.",
   "scripts": {
     "build": "wp-scripts build",
     "start": "wp-scripts start",


### PR DESCRIPTION
## Summary

The FakerPress generators wrote `status`/`type` values that are **not valid members of the EasyCommerce core DB ENUMs**. In non-strict MySQL these silently coerce to `''`; where a generator also *reads* by status, the query returns zero rows. Net effect: **order generation failed completely** and several tables accumulated garbage statuses.

Root cause traced live (debug.log): `[order] Single item generation failed: No product variations found` — the order generator filtered variations by `status='active'`, which is not in the `product_variations.status` ENUM.

## Functional fixes
- **Order**: variation lookup `status='active'` → `IN ('in_stock','backorder')` (the blocker — every order aborted).
- **Order**: removed undefined `$order->get_order_number()` call (fatal); use `ORD-{id}`.
- **Order**: dropped `cancelled` from the `fulfill_status` pool (not in `orders.fulfill_status`).
- **Product**: `determine_stock_status()` no longer returns `low_stock` (not in `product_variations.status`).
- **Product_Variation**: status enum fixed (was `active|inactive|draft`).
- **Transaction**: `type` limited to `payment|refund|adjustment` (dropped `fee|commission`); `status` pool dropped `cancelled` in favour of `refunded`.
- **Refund**: `status` now `pending|approved|processed|rejected` (was `completed|failed`).

## Hardening
- `is_easycommerce_active()`: `require_once wp-admin/includes/plugin.php` before `is_plugin_active()` (not loaded on REST/front-end).
- `extract_zip()`: reject zip entries with absolute or `../` paths (zip-slip).
- ABSPATH direct-access guard added to 25 `includes/` class files.

## Docs / metadata
- CLAUDE.md: 11 → 14 generators, corrected React UI architecture, `generate_items()`, add-a-generator steps.
- `@version` 2.0.3 → 2.2.0; `.pot` Project-Id-Version 2.0.4 → 2.2.0; composer/package descriptions 11 → 14; Transaction `@package` qualifier.

## Verification
- Live-ran each affected generator: orders create with line items; refunds create with valid statuses; transactions only emit `payment`/`adjustment` + valid status — no `''` coercion; variations include valid `out_of_stock`.
- Cleaned pre-fix stale rows (6 empty-status variations, 2 broken orders + children).
- `php -l` clean on all changed files; **phpcs (WPCS) 28/28 clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)