### PR TITLE
docs: fix WP.org readme compliance and modernise README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to EasyCommerce FakerPress
+
+Thanks for taking the time to contribute. This guide covers the setup, conventions, and checks this project expects.
+
+## Reporting bugs and requesting features
+
+Open an issue on the [issue tracker](https://github.com/mralaminahamed/easycommerce-fakerpress/issues). For bugs, include the WordPress version, PHP version, EasyCommerce version, plugin version, the generator involved, and the steps that reproduce the problem.
+
+> [!IMPORTANT]
+> Do not report security vulnerabilities through public issues. Follow the [security policy](SECURITY.md) instead.
+
+## Local setup
+
+Requires PHP 7.4+, Composer, Node.js 20+, Yarn, and a WordPress site with [EasyCommerce](https://wordpress.org/plugins/easycommerce/) active.
+
+```bash
+git clone https://github.com/mralaminahamed/easycommerce-fakerpress.git
+cd easycommerce-fakerpress
+composer install
+yarn install
+yarn build      # or: yarn start, for webpack watch mode
+```
+
+## Before opening a pull request
+
+CI runs PHPCS and PHPStan on every push, so run both locally first:
+
+```bash
+composer phpcs      # WordPress coding standards (composer phpcbf auto-fixes)
+composer phpstan    # Static analysis, level 8
+composer test       # PHPUnit
+yarn test:e2e       # Playwright end-to-end suite
+```
+
+## Coding conventions
+
+**PHP** follows WordPress Coding Standards with PSR-4 autoloading under the `EasyCommerceFakerPress\` namespace. Methods are camelCase, file names are snake_case. All code must pass PHPStan level 8.
+
+**TypeScript** is strict mode, functional components and hooks only, styled with Tailwind v4. The `@` path alias resolves to `src/`.
+
+**REST endpoints** use plural resource bases (`products`, `orders`) under the `easycommerce-fakerpress/v1` namespace, with parameters validated via JSON Schema in each controller's `get_params()`.
+
+## Adding a generator
+
+Four things are required, and a generator is incomplete without all of them:
+
+1. `includes/Generators/Foo.php` — extends `Abstracts\Generator`
+2. `includes/Controllers/Foo.php` — extends `Abstracts\Controller`
+3. A config entry in `src/admin/lib/generators.ts`, which drives the admin UI
+4. Controller registration in `class-easycommerce-fakerpress.php::register_rest_routes()`
+
+Add PHPUnit coverage for the generator and Playwright coverage for its UI.
+
+## Commits
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+type(scope): short description
+```
+
+Types in use: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`. Use a specific scope, such as `fix(generators):` or `docs(readme):`. See [`.github/git-commit-instructions.md`](.github/git-commit-instructions.md) for the full convention.
+
+Branch names follow the same shape as the commit type — for example `fix/generator-status-enums` or `docs/add-screenshots`.
+
+## Documentation
+
+`README.md` is for developers and contributors; `readme.txt` is the WordPress.org listing and holds the canonical changelog. When a change affects end users, update `readme.txt`. Keep facts such as version numbers and compatibility in a single place rather than duplicating them across both files.
+
+If a change adds an outbound HTTP request, it must be disclosed in the `== External services ==` section of `readme.txt` and in the External Services table in `README.md`. WordPress.org requires this.
+
+## License
+
+Contributions are licensed under [GPL-2.0-or-later](LICENSE), matching the plugin.

--- a/README.md
+++ b/README.md
@@ -1,95 +1,23 @@
 # EasyCommerce FakerPress
 
-[![WordPress Plugin](https://img.shields.io/badge/WordPress-Plugin-blue.svg)](https://wordpress.org/plugins/easycommerce-fakerpress/)
-[![License](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](http://www.gnu.org/licenses/gpl-2.0.txt)
-[![PHP](https://img.shields.io/badge/PHP-7.4%2B-8892BF.svg)](https://php.net/)
-[![Version](https://img.shields.io/badge/Version-2.1.0-green.svg)]()
+[![WordPress plugin version](https://img.shields.io/wordpress/plugin/v/easycommerce-fakerpress?style=flat-square)](https://wordpress.org/plugins/easycommerce-fakerpress/)
+[![WordPress version tested up to](https://img.shields.io/wordpress/plugin/tested/easycommerce-fakerpress?style=flat-square)](https://wordpress.org/plugins/easycommerce-fakerpress/)
+[![Minimum PHP version required](https://img.shields.io/wordpress/plugin/required-php/easycommerce-fakerpress?style=flat-square)](https://wordpress.org/plugins/easycommerce-fakerpress/)
+[![Total downloads from WordPress.org](https://img.shields.io/wordpress/plugin/dt/easycommerce-fakerpress?style=flat-square)](https://wordpress.org/plugins/easycommerce-fakerpress/advanced/)
+[![License GPL v2 or later](https://img.shields.io/badge/license-GPL--2.0--or--later-blue?style=flat-square)](LICENSE)
 
-Generate realistic test data for your EasyCommerce store. 14 specialized generators, modern admin UI, run history, configurable settings, and sample data sync from GitHub.
+Generate realistic test data for EasyCommerce stores — 14 generators, live preview, batch queue, and a modern admin UI.
 
----
+> [!WARNING]
+> This plugin writes large volumes of fake data directly into your store. Use it only on development or staging sites, and back up your database before generating large datasets.
 
-## What It Does
+![EasyCommerce FakerPress dashboard showing stat cards with sparklines, a recent-activity feed, and a generator grid grouped by category](.wordpress-org/screenshot-1.png)
 
-EasyCommerce FakerPress populates your EasyCommerce store with realistic fake data for development, testing, and demos. Choose a generator, configure the parameters, and click Generate.
+## Quick Start
 
-**Use cases:**
-- Developing new features that need existing store data
-- Testing plugins, themes, and integrations against realistic datasets
-- Creating client demos with populated product catalogs and orders
-- Performance testing with large datasets
+Install from the WordPress admin — **Plugins → Add New**, search for "EasyCommerce FakerPress", then **Install Now** and **Activate**. The plugin appears as **EC FakerPress** in the admin menu.
 
----
-
-## Generators
-
-### Core
-| Generator | Description |
-|-----------|-------------|
-| Products | Products with pricing, categories, inventory, and variations |
-| Customers | Customer profiles with addresses, demographics, and purchase history |
-| Orders | Complete order histories with payments, shipping, and tax |
-| Coupons | Discount codes with rules, usage limits, and restrictions |
-
-### Advanced
-| Generator | Description |
-|-----------|-------------|
-| Product Variations | Variable product attributes, price variance, and stock settings |
-| Shipping Plans | Shipping methods, zones, and rate tables |
-| Tax Classes | Tax rules and classes for different regions and product types |
-| Transactions | Payment transaction records with multiple gateways and statuses |
-| Cart Sessions | Shopping cart abandonment scenarios and session data |
-| Attributes | Product attribute types (Text, Color, Image) for variations |
-| Refunds | Refund records against existing completed or processing orders |
-| Logs | Activity log entries for orders, products, customers, and system events |
-
-### Enhanced
-| Generator | Description |
-|-----------|-------------|
-| Locations | Geographic data including countries, states, and cities |
-| Product Reviews | Product reviews with ratings linked to existing products and customers |
-
----
-
-## Features
-
-- **Run History** — Per-generator run log stored in browser localStorage; recent runs shown in sidebar; all-time stats on the dashboard
-- **Settings** — Default count, locale, seed, and metadata preference; configurable max run history; sample data sync from GitHub
-- **Sample Data Sync** — One-click download of locale-specific reference data (75+ locales) from the companion repository
-- **Our Plugins Page** — Browse the author's other WordPress.org plugins with live data
-- **Hook System** — 15+ filters and actions for complete data customization
-- **REST API** — 14 REST controllers under `easycommerce-fakerpress/v1`
-- **Playwright E2E Suite** — 131 automated tests covering all generators, field types, and UI interactions
-
----
-
-## Requirements
-
-- WordPress 5.0+
-- PHP 7.4+ (8.0+ recommended)
-- EasyCommerce plugin (required, must be active)
-- Composer (for PHP dependencies)
-- Node.js 20+ (development only)
-
----
-
-## Installation
-
-### From WordPress.org
-
-1. Go to **Plugins > Add New** in your WordPress admin
-2. Search for "EasyCommerce FakerPress"
-3. Click **Install Now**, then **Activate**
-4. Access via **EC FakerPress** in the admin menu
-
-### Manual
-
-1. Download the plugin ZIP
-2. Upload to `/wp-content/plugins/easycommerce-fakerpress/`
-3. Run `composer install` in the plugin directory
-4. Activate via the Plugins screen
-
-### Development
+To run it from source instead:
 
 ```bash
 git clone https://github.com/mralaminahamed/easycommerce-fakerpress.git
@@ -99,12 +27,124 @@ yarn install
 yarn build
 ```
 
----
+Requires [EasyCommerce](https://wordpress.org/plugins/easycommerce/), declared as a hard dependency via the `Requires Plugins` header — WordPress blocks activation until EasyCommerce is installed and active. Minimum WordPress, PHP, and tested-up-to versions are shown in the badges above; `readme.txt` and the plugin header are the source of truth. Node.js 20+ is needed for development only.
 
-## Commands
+## What It Does
+
+EasyCommerce FakerPress populates your EasyCommerce store with realistic fake data for development, testing, and demos. Choose a generator, configure the parameters, and click Generate.
+
+- Developing features that need existing store data
+- Testing plugins, themes, and integrations against realistic datasets
+- Building client demos with populated catalogs and order histories
+- Performance testing with large datasets
+
+## Generators
+
+Fourteen generators, grouped by category in the admin.
+
+| Generator | Category | Description |
+|-----------|----------|-------------|
+| Products | Core | Products with pricing, categories, inventory, and variations |
+| Customers | Core | Customer profiles with addresses, demographics, and purchase history |
+| Orders | Core | Complete order histories with payments, shipping, and tax |
+| Coupons | Core | Discount codes with rules, usage limits, and restrictions |
+| Product Variations | Advanced | Variable product attributes, price variance, and stock settings |
+| Shipping Plans | Advanced | Shipping methods, zones, and rate tables |
+| Tax Classes | Advanced | Tax rules and classes for different regions and product types |
+| Transactions | Advanced | Payment transaction records with multiple gateways and statuses |
+| Cart Sessions | Advanced | Shopping cart abandonment scenarios and session data |
+| Attributes | Advanced | Product attribute types (Text, Color, Image) for variations |
+| Refunds | Advanced | Refund records against existing completed or processing orders |
+| Logs | Advanced | Activity log entries for orders, products, customers, and system events |
+| Locations | Enhanced | Geographic data including countries, states, and cities |
+| Product Reviews | Enhanced | Product reviews with ratings linked to existing products and customers |
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| Design-token UI | Light/dark themes, 5 accent palettes, comfortable/compact density — all scoped to the plugin so WordPress chrome is never restyled |
+| Live preview | A read-only REST preview route returns real faker rows without persisting anything; the table refreshes as you change settings and re-rolls on Shuffle |
+| Command palette | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd> to quick-jump to any generator or page |
+| Batch queue | Queue multiple generators and run them sequentially from the batch tray, with live progress |
+| Run history | Per-generator run log in browser localStorage; recent runs in the sidebar, all-time stats on the dashboard |
+| Settings | Default count, locale, seed, metadata preference, run-history limit, and sample data sync |
+| Sample data sync | One-click download of locale-specific reference data (75+ locales) from the companion repository |
+| Hook system | 15+ filters and actions for data customization |
+| REST API | 14 controllers under `easycommerce-fakerpress/v1` |
+| E2E suite | 131 Playwright tests covering all generators, field types, and UI interactions |
+
+## Screenshots
+
+<details>
+<summary>View all 11 screenshots</summary>
+
+### Generator page
+
+![Generator page with schema-driven config controls on the left, a live preview table on the right, and a sticky run bar](.wordpress-org/screenshot-2.png)
+
+Two-column layout with schema-driven config controls on the left and a live preview table on the right, plus a sticky run bar.
+
+### Live preview
+
+![Live preview table showing real faker sample rows with a Shuffle button](.wordpress-org/screenshot-3.png)
+
+Real faker sample rows that refresh as you change settings, with a Shuffle button to re-roll the seed. No data is persisted.
+
+### Command palette
+
+![Command palette overlay listing generators and pages for quick navigation](.wordpress-org/screenshot-4.png)
+
+Press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd> to quick-jump to any generator or page.
+
+### Batch queue
+
+![Batch tray showing several queued generators running sequentially with progress indicators](.wordpress-org/screenshot-5.png)
+
+Queue multiple generators and run them sequentially from the batch tray with live progress.
+
+### Tweaks panel
+
+![Tweaks panel with theme, accent palette, and density controls](.wordpress-org/screenshot-6.png)
+
+Switch theme (light/dark), accent palette, and density — applied live and persisted.
+
+### Dark mode
+
+![The plugin admin rendered in dark theme with WordPress chrome left untouched](.wordpress-org/screenshot-7.png)
+
+The full admin in dark theme, scoped to the plugin so WordPress chrome stays untouched.
+
+### Settings page
+
+![Settings page with generation defaults, run-history limit, sample-data sync status, About card, and Danger Zone](.wordpress-org/screenshot-8.png)
+
+Generation defaults, run-history limit, sample-data sync status, About card, and Danger Zone on the card system.
+
+### Our Plugins page
+
+![Our Plugins page showing WordPress.org plugin cards with ratings and active-install counts](.wordpress-org/screenshot-9.png)
+
+Live WordPress.org plugin cards with ratings, active-install counts, and direct links.
+
+### Product Reviews generator
+
+![Product Reviews generator configuration with product ID targeting, count, locale, seed, and metadata options](.wordpress-org/screenshot-10.png)
+
+Target a specific product by ID, configure count, locale, seed, and metadata options.
+
+### Locations generator
+
+![Locations generator configuration with region chip selects, country limits, and coordinate toggles](.wordpress-org/screenshot-11.png)
+
+Region chip selects, max countries, state and city generation toggles, cities-per-state range, and coordinate generation.
+
+</details>
+
+## Development
 
 ```bash
-# Development
+# JavaScript
 yarn start                   # Webpack watch mode
 yarn build                   # Production build
 
@@ -115,18 +155,25 @@ composer phpcbf              # Auto-fix coding standards
 composer phpstan             # Static analysis (level 8)
 composer release             # Lint + analyse + build + makepot + zip
 
-# E2E tests
-yarn test:e2e:setup          # Configure WP test environment
+# End-to-end tests
+yarn test:e2e:setup          # Configure the WP test environment
 yarn test:e2e                # Run all 131 Playwright tests
 yarn test:e2e:ui             # Playwright interactive UI
-yarn test:e2e:report         # Open HTML test report
+yarn test:e2e:report         # Open the HTML test report
 ```
-
----
 
 ## Architecture
 
-### PHP
+```mermaid
+flowchart LR
+    A["React admin<br/>src/admin"] -->|"POST /easycommerce-fakerpress/v1/{resource}/generate"| B["Controller<br/>generate_items()"]
+    B -->|"JSON Schema validation"| C["Generator<br/>generate()"]
+    C -->|FakerPHP| D["EasyCommerce models"]
+    D --> E["WordPress database"]
+    C -->|"{ id, message, metadata }"| A
+```
+
+PHP lives under the PSR-4 namespace `EasyCommerceFakerPress\`:
 
 ```
 easycommerce-fakerpress.php          Plugin bootstrap
@@ -139,19 +186,7 @@ includes/
   MCP/                               MCP server + abilities
 ```
 
-### REST API
-
-```
-POST /easycommerce-fakerpress/v1/{resource}/generate
-```
-
-Params validated via JSON Schema in each controller's `get_params()`. Returns `{ id, message, metadata }`.
-
-### JS
-
-Built with React 18, React Router v7, Radix UI, and Tailwind CSS v4. Entry point: `src/index.tsx`. Output: `build/app.js`.
-
----
+The admin app is React 18, React Router v7, Radix UI, and Tailwind CSS v4. Entry point `src/index.tsx`, built to `build/app.js`. The compiled bundle is the only JS shipped to WordPress.org; the readable source lives in this repository.
 
 ## Extensibility
 
@@ -162,103 +197,49 @@ add_filter( 'easycommerce_fakerpress_product_data_before_create', function( $dat
     return $data;
 } );
 
-// Hook after item created
+// Hook after an item is created
 add_action( 'easycommerce_fakerpress_after_product_created', function( $product_id, $data ) {
     // custom logic
 }, 10, 2 );
 
-// Filter REST response
+// Filter the REST response
 add_filter( 'easycommerce_fakerpress_rest_response', function( $response, $request ) {
     return $response;
 }, 10, 2 );
 ```
 
----
+## External Services
 
-## Screenshots
+Two outbound requests, both administrator-initiated. Neither sends any site, user, or store data.
 
-### Dashboard
+| Service | Endpoint | Triggered by | Data sent |
+|---------|----------|--------------|-----------|
+| GitHub | `github.com/mralaminahamed/easycommerce-fakerpress-sample-data/archive/refs/heads/trunk.zip` | Clicking **Sync Sample Data** in Settings, or a generator needing sample data not yet downloaded | Unauthenticated `GET`; no payload |
+| WordPress.org | `api.wordpress.org/plugins/info/1.2/` | Opening the **Our Plugins** page; the request is made by the browser | Author query string only; no payload |
 
-![Dashboard](.wordpress-org/screenshot-1.png)
-Stats bar with live generation counts and generator grid grouped by category (Core, Advanced, Enhanced).
-
-### Products Generator
-
-![Products Generator](.wordpress-org/screenshot-2.png)
-Two-panel layout: sidebar with category nav and run history, params panel, sticky action panel.
-
-### Customers Generator
-
-![Customers Generator](.wordpress-org/screenshot-3.png)
-Customer type and age group chip selects, address preference toggles, purchase history options.
-
-### Orders Generator
-
-![Orders Generator](.wordpress-org/screenshot-4.png)
-Order status selector, customer distribution controls, items-per-order range, payment methods.
-
-### Coupons Generator
-
-![Coupons Generator](.wordpress-org/screenshot-5.png)
-Discount type chips, discount range inputs, usage limits, validity period, and restrictions.
-
-### Product Variations Generator
-
-![Product Variations Generator](.wordpress-org/screenshot-6.png)
-Product type selection, price variance range, stock management, variation attribute settings.
-
-### Transactions Generator
-
-![Transactions Generator](.wordpress-org/screenshot-7.png)
-Transaction types, payment gateways, amount range, and status distribution controls.
-
-### Settings Page
-
-![Settings Page](.wordpress-org/screenshot-8.png)
-Default count, locale, seed, metadata toggle; run history limit; sample data sync; About card; Danger Zone.
-
-### Our Plugins Page
-
-![Our Plugins](.wordpress-org/screenshot-9.png)
-Live WordPress.org plugin cards with ratings, active install counts, and direct links.
-
-### Product Reviews Generator
-
-![Product Reviews Generator](.wordpress-org/screenshot-10.png)
-Target specific products by ID, count, locale, seed, and metadata options.
-
-### Locations Generator
-
-![Locations Generator](.wordpress-org/screenshot-11.png)
-Region chip selects, max countries, states, cities per state, and coordinate generation.
-
----
+GitHub [terms](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service) and [privacy policy](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). WordPress.org [about](https://wordpress.org/about/) and [privacy policy](https://wordpress.org/about/privacy/).
 
 ## Security
 
-- All REST endpoints require `manage_options` capability
-- Parameters validated via JSON Schema before processing
-- Generated data is fictional — for non-production use only
-- No external data transmission; all data stays in your WordPress database
+- All REST endpoints require the `manage_options` capability
+- Parameters are validated against JSON Schema before processing
+- Generated data is fictional and intended for non-production use only
+- Generated data stays in your own database; no analytics, telemetry, or phone-home
 
----
+Report vulnerabilities privately — see the [security policy](SECURITY.md).
+
+## Changelog
+
+The canonical changelog lives in [`readme.txt`](readme.txt) and is rendered on the [WordPress.org changelog page](https://wordpress.org/plugins/easycommerce-fakerpress/#developers).
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch
-3. Follow WordPress Coding Standards and PSR-4
-4. Add tests for new generators (PHPUnit + Playwright)
-5. Submit a pull request
+Bug reports, feature requests, and pull requests are welcome. Read the [contributing guide](CONTRIBUTING.md) before opening a pull request, and file issues on the [issue tracker](https://github.com/mralaminahamed/easycommerce-fakerpress/issues).
 
-Report bugs and request features via [GitHub Issues](https://github.com/mralaminahamed/easycommerce-fakerpress/issues).
+## Maintainer
 
----
+Al Amin Ahamed — [alaminahamed.com](https://alaminahamed.com) · [@mralaminahamed](https://github.com/mralaminahamed)
 
 ## License
 
-GPL v2 or later. See [LICENSE](LICENSE).
-
-## Author
-
-Al Amin Ahamed — [alaminahamed.com](https://alaminahamed.com) — [@mralaminahamed](https://github.com/mralaminahamed)
+[GPL-2.0-or-later](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<div align="center">
+
 # EasyCommerce FakerPress
 
 [![WordPress plugin version](https://img.shields.io/wordpress/plugin/v/easycommerce-fakerpress?style=flat-square)](https://wordpress.org/plugins/easycommerce-fakerpress/)
@@ -7,6 +9,8 @@
 [![License GPL v2 or later](https://img.shields.io/badge/license-GPL--2.0--or--later-blue?style=flat-square)](LICENSE)
 
 Generate realistic test data for EasyCommerce stores — 14 generators, live preview, batch queue, and a modern admin UI.
+
+</div>
 
 > [!WARNING]
 > This plugin writes large volumes of fake data directly into your store. Use it only on development or staging sites, and back up your database before generating large datasets.

--- a/easycommerce-fakerpress.php
+++ b/easycommerce-fakerpress.php
@@ -14,6 +14,7 @@
  * Version:           2.2.0
  * Requires at least: 5.0
  * Requires PHP:      7.4
+ * Requires Plugins:  easycommerce
  * Author:            Al Amin Ahamed
  * Author URI:        https://github.com/mralaminahamed/
  * Text Domain:       easycommerce-fakerpress

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,9 @@ Tags: ecommerce, faker, data-generation, testing, development
 Requires at least: 5.0
 Tested up to: 6.9
 Requires PHP: 7.4
+Requires Plugins: easycommerce
 Stable tag: 2.2.0
-License: GPL v2 or later
+License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Generate realistic EasyCommerce test data with 14 generators, modern SaaS UI, run history, settings, and sample data sync from GitHub.
@@ -57,6 +58,46 @@ The plugin exposes a full hook system for developers:
 * `easycommerce_fakerpress_rest_response` — Filter REST API responses
 
 **Important**: Use only in development or staging environments. Back up your database before generating large datasets.
+
+== External services ==
+
+This plugin connects to two external services. Neither is contacted on activation, and no personal or store data is ever transmitted.
+
+**1. GitHub — sample data repository**
+
+The Settings page offers an optional "Sample Data Sync" action that downloads locale-specific reference data (product names, addresses, customer tags for 75+ locales) used to make generated content more realistic.
+
+Service: GitHub
+Endpoint: https://github.com/mralaminahamed/easycommerce-fakerpress-sample-data/archive/refs/heads/trunk.zip
+When data is sent: Only when an administrator clicks "Sync Sample Data" on the plugin Settings page, or when a generator requires sample data that has not been downloaded yet.
+Data sent: An unauthenticated HTTP GET request. No site, user, or store data is included — only the request itself (and the IP address and user agent inherent to any HTTP request).
+Terms of Service: https://docs.github.com/en/site-policy/github-terms/github-terms-of-service
+Privacy Policy: https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement
+
+**2. WordPress.org — plugin directory API**
+
+The "Our Plugins" admin page lists the plugin author's other WordPress.org plugins with live ratings and install counts.
+
+Service: WordPress.org Plugin Directory API
+Endpoint: https://api.wordpress.org/plugins/info/1.2/
+When data is sent: Only when an administrator opens the "Our Plugins" page in the plugin admin. The request is made by the browser.
+Data sent: A query for plugins by the author "mralaminahamed". No site, user, or store data is included — only the request itself (and the IP address and user agent inherent to any HTTP request).
+Terms of Service: https://wordpress.org/about/
+Privacy Policy: https://wordpress.org/about/privacy/
+
+== Source code ==
+
+The minified JavaScript and CSS in `build/` is compiled from the TypeScript and CSS sources in `src/`, which are not included in the distributed plugin package. The complete, human-readable source is public:
+
+https://github.com/mralaminahamed/easycommerce-fakerpress
+
+Build steps:
+
+`composer install`
+`yarn install`
+`yarn build`
+
+Build tooling: webpack (via @wordpress/scripts), TypeScript, and Tailwind CSS. Configuration files (`webpack.config.js`, `tsconfig.json`, `postcss.config.js`) are in the repository root.
 
 == Installation ==
 
@@ -193,6 +234,9 @@ Run history is stored in browser localStorage. It does not affect your database.
 
 == Upgrade Notice ==
 
+= 2.2.0 =
+Complete admin UI redesign with a new design-token system, dashboard, live preview, command palette, batch queue, and dark mode. No database migrations required. REST API, generator parameters, and custom hooks are unchanged.
+
 = 2.1.0 =
 Major feature release. Complete admin UI redesign, 3 new generators, Settings page, sample data sync, Our Plugins page, and Playwright e2e suite. No database migrations required. REST API and custom hooks are unchanged.
 
@@ -203,7 +247,9 @@ Breaking change: parameter schemas updated for all generators. Review custom RES
 
 **Privacy**
 
-All data is stored in your WordPress database. No external transmissions occur. Generated content is fictional and does not represent real individuals or transactions.
+All generated data is stored in your own WordPress database and is never transmitted anywhere. Generated content is fictional and does not represent real individuals or transactions. The plugin does not collect analytics, does not phone home, and does not send any site, user, or store data to a third party.
+
+The plugin makes two outbound requests, both administrator-initiated and both carrying no site data — see the "External services" section above for the full disclosure.
 
 **Contributing**
 


### PR DESCRIPTION
## Why

An audit of both readme files against current WordPress.org requirements and GitHub README conventions turned up three compliance problems and a set of stale content. The most serious is that `readme.txt` asserted something untrue about the plugin's network behaviour.

## WordPress.org compliance

**The Privacy section was factually wrong.** It stated "No external transmissions occur." The plugin makes two outbound requests:

| Service | Where | Trigger |
|---|---|---|
| GitHub sample-data archive | `class-easycommerce-fakerpress.php:552` (`wp_remote_get`) | Admin clicks **Sync Sample Data**, or a generator needs sample data not yet downloaded |
| `api.wordpress.org/plugins/info/1.2/` | `src/admin/components/Pages/PluginsPage.tsx:26` (browser `fetch`) | Admin opens the **Our Plugins** page |

Neither sends site, user, or store data, and neither fires on activation — but WP.org requires both to be disclosed in an `== External services ==` section regardless, and the previous wording claimed the opposite of the truth. Added that section in the expected format, with terms and privacy URLs for both services. All URLs verified HTTP 200.

**No source for compiled output.** `.distignore` excludes `/src/`, so the shipped package contains `build/app.js` with no readable counterpart. Added an `== Source code ==` section pointing at this repository with the build steps, which is the accepted remedy when source is not bundled.

**Missing `Requires Plugins` header.** The plugin has always been unusable without EasyCommerce and gates every REST route and the admin menu behind `check_dependencies()`, but never declared the dependency to core. Added `Requires Plugins: easycommerce` to both the plugin header and `readme.txt`, so WordPress blocks activation itself. The `easycommerce` slug is confirmed present on WP.org.

Also: `License` normalised to the canonical `GPLv2 or later`, and an `Upgrade Notice` entry added for 2.2.0, which was missing even though 2.2.0 is the stable tag.

Validated against the [official WP.org readme validator](https://wordpress.org/plugins/developers/readme-validator/): **no errors, no warnings**. The only note is "No donate link was found", which is optional.

## README.md

`README.md` was last substantively updated for 2.1.0 and had drifted:

- Version badge hardcoded to **2.1.0** while the plugin shipped **2.2.0**
- **Screenshot captions no longer matched their images.** The assets were replaced for the 2.2.0 redesign in #9, but the captions were not, so everything from `screenshot-2` onward described a different screen than the one shown
- Feature list predated the command palette, batch queue, live preview, and theming
- Security section carried the same false "No external data transmission" claim

Restructured against current guidance (GitHub docs, Standard Readme, makeareadme.com):

- **Live badges instead of hardcoded ones.** Version, tested-up-to, required-PHP, and downloads now come from shields.io WordPress endpoints that read the WP.org API, so they cannot go stale. Static version badges are considered an anti-pattern for precisely the failure seen here. All five verified to resolve.
- Install moved above the fold, ahead of the long description
- Descriptive alt text on every image and badge
- 11-screenshot gallery collapsed into `<details>` to keep the page scannable
- Mermaid diagram for the request flow, rendered natively by GitHub
- One `> [!WARNING]` alert for the non-production warning
- **Changelog no longer duplicated** — links to `readme.txt` as the single source of truth, avoiding the drift that caused the problems above
- Contributing extracted to `CONTRIBUTING.md`; License is now the final section, as an SPDX identifier

## CONTRIBUTING.md

New file — GitHub's community profile expects it as a separate file rather than a README section. Covers local setup, the checks CI enforces (PHPCS, PHPStan level 8, PHPUnit, Playwright), coding conventions, the four steps required to add a generator, the Conventional Commits format already in use, and a rule that any new outbound request must be disclosed in both readmes.

## Deliberately not changed

`Tested up to: 6.9` is left alone. Current core is **7.0.2**, so this is a release behind — but bumping it asserts compatibility that has not been tested. Worth a smoke test on WP 7.0 and a separate bump, rather than being changed as part of a docs PR.

## Verification

- `php -l easycommerce-fakerpress.php` — clean
- Official WP.org readme validator — no errors, no warnings
- All 5 shields.io badge endpoints return live data
- All relative links (`LICENSE`, `SECURITY.md`, `CONTRIBUTING.md`, `readme.txt`, `.github/git-commit-instructions.md`) resolve
- All 11 screenshot paths resolve; count matches `readme.txt` and `.wordpress-org/`
- All external URLs return HTTP 200
- Heading levels are sequential; no images or badges missing alt text

`composer phpcs` / `phpstan` were not run locally — `vendor/` is not installed in this worktree. CI covers both. Only change to a PHP file is one header comment line.
