### PR TITLE
docs: split changelog into CHANGELOG.md, keep last 4 releases in readme.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,197 @@
+# Changelog
+
+All notable changes to EasyCommerce FakerPress are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Release dates are taken from the release tags in this repository. The [`readme.txt`](readme.txt) changelog carries only the most recent releases, as WordPress.org recommends; this file is the complete history.
+
+## [Unreleased]
+
+## [2.2.0] - 2026-06-11
+
+### Added
+
+- Dashboard with stat cards and sparklines, a recent-activity feed, and a generator grid grouped by category, all driven by real run history.
+- Live preview. A read-only REST preview route returns real faker rows without persisting anything; the preview table refreshes as settings change and re-rolls on Shuffle.
+- Command palette, opened with Cmd/Ctrl+K, for jumping to any generator or page.
+- Batch queue. Multiple generators can be queued and run sequentially from the batch tray, with progress and toasts.
+- Tweaks panel with live theme, accent, and density controls, persisted to the browser.
+
+### Changed
+
+- Complete admin UI redesign on a new design-token system: self-hosted Geist fonts, light and dark themes, five accent palettes, and comfortable/compact density. All styles are scoped to the plugin so WordPress chrome is never restyled.
+- Generator page rebuilt as a two-column config and preview layout with a sticky run bar carrying the count stepper, seed, metadata toggle, add-to-batch, and generate controls.
+- Settings and Our Plugins pages rebuilt on the new card system.
+- Refreshed brand assets: new logo, recolorable admin menu icon, and updated WordPress.org icon and banners.
+
+## [2.1.0] - 2026-04-26
+
+### Added
+
+- Three generators: Attributes, Refunds, and Logs, bringing the total to 14.
+- Run history. A per-generator run log in localStorage with a configurable FIFO limit, recent runs in the sidebar, and all-time stats on the dashboard.
+- Settings page covering default count, locale, seed, and metadata toggle, plus the run-history limit, sample data sync, an About card, and Reset Settings.
+- Sample data sync. Locale-specific reference data can be downloaded or force re-synced from the companion GitHub repository via REST endpoints.
+- Our Plugins page, listing the author's other WordPress.org plugins with live data.
+- Global sticky navigation for Generators, Settings, and Our Plugins.
+- Playwright end-to-end suite: 131 tests covering the home page, generator page layout, ActionPanel interactions, all six field types, and all 14 generators.
+
+### Changed
+
+- Admin UI redesigned in a modern SaaS style with clean white, blue, and indigo accents.
+- Generator page reworked with a sticky top bar, a collapsible sidebar carrying category navigation and per-generator run history, and a two-panel params and action layout.
+- Component architecture reworked: the 757-line `GeneratorBase` monolith was replaced with focused `ParamsPanel`, `ActionPanel`, and `GeneratorSidebar` components, and parameter configuration was centralised in `generators.ts`.
+
+### Fixed
+
+- Category matching now works in all locales.
+- Only a single `ActionPanel` instance is rendered in the DOM.
+- Focus styles are scoped to the plugin.
+- `RangeField` error colour corrected.
+- Nested route active state resolves correctly.
+
+## [2.0.4] - 2026-02-26
+
+### Changed
+
+- Shared TypeScript type definitions extracted into their own module; generators and components now consume a shared `GeneratorResult` type.
+- Webpack configuration updated, with a `TerserPlugin` configuration added for WordPress compatibility.
+- Build output renamed from `index` to `app`, and the asset file path updated to match the entry point.
+- Dependencies updated, including PHPStan 2.1.40.
+
+### Fixed
+
+- Corrected the import path for the shared types module.
+
+### Removed
+
+- Leftover `console.log` calls in components.
+- `package-lock.json`, since Yarn provides the lockfile.
+
+## [2.0.3] - 2026-01-14
+
+### Added
+
+- Product Review generator with weighted rating distribution and verified-purchase support.
+- WordPress comments integration for review storage.
+
+### Changed
+
+- Controller pattern and API schema made consistent across generators.
+
+### Fixed
+
+- Order generator data structure now matches the EasyCommerce `Order` model.
+- Order notes are created through the `Order_Notes` model.
+
+## [2.0.2] - 2026-01-14
+
+### Added
+
+- "Get Started" plugin action link on the Plugins screen.
+
+### Changed
+
+- Upgraded to Tailwind CSS v4.
+- Build system and dependency compatibility updates.
+
+### Fixed
+
+- Visual inconsistencies in success messages and navigation.
+
+## [2.0.1] - 2025-11-13
+
+### Fixed
+
+- Minor bug fixes and code quality improvements.
+
+## [2.0.0] - 2025-11-11
+
+### Changed
+
+- **Breaking:** Parameter schemas were realigned across all 10 generators. Custom REST API integrations and hooks that pass generator parameters must be reviewed before upgrading.
+- Full TypeScript migration with proper interfaces and validation.
+
+### Fixed
+
+- Array versus string mismatches and naming inconsistencies across all REST controllers.
+
+## [1.0.4] - 2025-11-10
+
+### Added
+
+- Sample dataset for locales.
+
+### Fixed
+
+- Deployment issues in the release workflow.
+
+## [1.0.3] - 2025-10-29
+
+### Added
+
+- Hook system exposing 15+ filters and actions for data customisation.
+- REST response filtering for API extensibility.
+
+### Changed
+
+- Plugin descriptions expanded to document the hook system.
+
+### Fixed
+
+- Release name format and plugin name in the GitHub release workflow.
+- Indentation issue in the GitHub workflow.
+
+## [1.0.2] - 2025-10-26
+
+### Changed
+
+- Performance improvements for memory usage and processing speed.
+- Compatibility updates for the latest EasyCommerce features.
+
+### Fixed
+
+- Validation and error handling across all generators.
+
+## [1.0.1] - 2025-10-26
+
+### Changed
+
+- `readme.txt` simplified, with verbose sections removed and formatting converted to standard markdown.
+
+## [1.0.0] - 2025-10-26
+
+### Added
+
+- Real-time dependency checks via a new REST controller.
+
+### Changed
+
+- PHPStan level 8 compliance.
+- Build system and documentation improvements.
+
+## 0.9.0 - 2025-09-15
+
+No release tag exists for this version, so it has no comparison link.
+
+### Added
+
+- Initial release with 10 core generators.
+- WordPress admin colour integration.
+- React 18 interface with real-time feedback.
+- PSR-4 architecture with native EasyCommerce model integration.
+
+[Unreleased]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.0.4...v2.1.0
+[2.0.4]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.0.3...v2.0.4
+[2.0.3]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.0.2...v2.0.3
+[2.0.2]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v1.0.4...v2.0.0
+[1.0.4]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/mralaminahamed/easycommerce-fakerpress/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,19 @@ React component → REST POST /easycommerce-fakerpress/v1/{resource}/generate
 - REST: plural endpoint bases (`products`, `orders`); params validated via JSON Schema in controller `get_params()`
 - Adding a generator requires: new `includes/Generators/Foo.php`, new `includes/Controllers/Foo.php`, a config entry in `src/admin/lib/generators.ts`, and registering the controller in `class-easycommerce-fakerpress.php::register_rest_routes()`
 - Plugin requires EasyCommerce to be active; all REST routes and the admin menu are gated behind `check_dependencies()`
+
+## Documentation conventions
+
+Three doc files, three audiences. Do not duplicate content between them — duplication is what caused every drift bug this repo has had.
+
+- `CHANGELOG.md` — **the complete version history, and the single source of truth.** [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) format: newest first, `YYYY-MM-DD` dates, and only the six headings `Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` / `Security`. Mark breaking changes as `- **Breaking:** …` inside the relevant heading. Add entries under `## [Unreleased]` as work lands; on release, rename that to the version with its date and add the compare link at the bottom of the file.
+- `readme.txt` — WordPress.org listing. Its `== Changelog ==` carries **only the four most recent releases**, above an absolute link to `CHANGELOG.md` on GitHub. Never a relative link: readme.txt renders on wordpress.org, so a relative path 404s. `== Upgrade Notice ==` must stay here — core reads it for the update prompt — and each entry is capped at 300 characters.
+- `README.md` — GitHub, developer-facing. Links to `CHANGELOG.md`; never restates release history.
+
+Release dates come from the git tag, not from memory. `readme.txt` dates have drifted from their tags before.
+
+`readme.txt` is **not** GitHub-flavored markdown. It is PHP Markdown Extra plus a `wp_kses` allowlist. `[text](url)`, `**bold**`, `` `code` ``, and lists work. Tables, images, ``` fences, and `#` headings are stripped. Version entries use `= 1.2.3 =`, which renders as `<h4>`. The changelog section truncates past 5,000 words.
+
+When a change adds an outbound HTTP request, it must be disclosed in `== External services ==` in `readme.txt` and in the External Services table in `README.md`. WordPress.org requires it.
+
+Verify `readme.txt` after editing: https://wordpress.org/plugins/developers/readme-validator/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,15 @@ Branch names follow the same shape as the commit type — for example `fix/gener
 
 ## Documentation
 
-`README.md` is for developers and contributors; `readme.txt` is the WordPress.org listing and holds the canonical changelog. When a change affects end users, update `readme.txt`. Keep facts such as version numbers and compatibility in a single place rather than duplicating them across both files.
+Three files, three audiences, no duplication:
+
+- **`CHANGELOG.md`** holds the complete version history in [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) format and is the single source of truth. Add your entry under `## [Unreleased]`, using one of the six headings — `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`. Describe the user-visible effect, not the commit; a reworded commit message is usually the wrong entry.
+- **`readme.txt`** is the WordPress.org listing. Its changelog keeps only the four most recent releases plus an absolute link to `CHANGELOG.md`, which is what WordPress.org recommends. At release time the `Unreleased` section is promoted into both files, and `== Upgrade Notice ==` is updated here.
+- **`README.md`** is for developers and links to `CHANGELOG.md` rather than restating history.
+
+Release dates come from the git tag. Keep version and compatibility facts in one place instead of retyping them.
+
+`readme.txt` is not GitHub-flavored markdown — tables, images, and ``` fences are stripped. Validate changes with the [readme validator](https://wordpress.org/plugins/developers/readme-validator/).
 
 If a change adds an outbound HTTP request, it must be disclosed in the `== External services ==` section of `readme.txt` and in the External Services table in `README.md`. WordPress.org requires this.
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Report vulnerabilities privately — see the [security policy](SECURITY.md).
 
 ## Changelog
 
-The canonical changelog lives in [`readme.txt`](readme.txt) and is rendered on the [WordPress.org changelog page](https://wordpress.org/plugins/easycommerce-fakerpress/#developers).
+The complete version history lives in [CHANGELOG.md](CHANGELOG.md), in [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) format. [`readme.txt`](readme.txt) carries only the four most recent releases, which is what WordPress.org recommends, and is rendered on the [WordPress.org changelog page](https://wordpress.org/plugins/easycommerce-fakerpress/#developers).
 
 ## Contributing
 

--- a/readme.txt
+++ b/readme.txt
@@ -165,6 +165,8 @@ Run history is stored in browser localStorage. It does not affect your database.
 
 == Changelog ==
 
+The four most recent releases are listed below. For the complete version history, see the [full changelog on GitHub](https://github.com/mralaminahamed/easycommerce-fakerpress/blob/trunk/CHANGELOG.md).
+
 = 2.2.0 - June 11, 2026 =
 * Complete admin UI redesign — Linear/Vercel-style SaaS interface built on a new design-token system (self-hosted Geist fonts, light/dark themes, 5 accent palettes, comfortable/compact density), all scoped to the plugin so WordPress chrome is never restyled
 * New dashboard — Stat cards with sparklines, recent-activity feed, and a generator grid grouped by category, all driven by real run history
@@ -190,47 +192,20 @@ Run history is stored in browser localStorage. It does not affect your database.
 * Playwright e2e suite — 131 automated tests covering the home page, generator page layout, ActionPanel interactions, all 6 field types, and all 14 generators
 * Bug fixes — Category matching in all locales; single ActionPanel DOM instance; scoped focus styles; RangeField error colour; nested route active state
 
-= 2.0.3 - January 15, 2026 =
+= 2.0.4 - February 26, 2026 =
+* Shared TypeScript type definitions extracted; generators and components now use a shared GeneratorResult type
+* Webpack configuration updated, with a TerserPlugin configuration for WordPress compatibility
+* Build output renamed from index to app, with the asset file path updated to match
+* Dependencies updated, including PHPStan 2.1.40
+* Fixed the import path for the shared types module
+* Removed leftover console.log calls and package-lock.json, since Yarn provides the lockfile
+
+= 2.0.3 - January 14, 2026 =
 * New Product Review generator with weighted rating distribution and verified purchase support
 * WordPress comments integration for review storage
 * Order generator data structure fix to match EasyCommerce Order model
 * Proper order notes creation using the Order_Notes model
 * Controller pattern and API schema consistency improvements
-
-= 2.0.2 - January 15, 2026 =
-* Added "Get Started" plugin action link
-* Upgraded to Tailwind CSS v4
-* Fixed visual inconsistencies in success messages and navigation
-* Build system and dependency compatibility updates
-
-= 2.0.1 - November 13, 2025 =
-* Minor bug fixes and code quality improvements
-
-= 2.0.0 - November 11, 2025 =
-* Complete parameter schema alignment for all 10 generators
-* Full TypeScript migration with proper interfaces and validation
-* Corrected array vs string mismatches and naming inconsistencies across all REST controllers
-* Breaking change: parameter schemas updated — review custom integrations before upgrading
-
-= 1.0.4 - November 10, 2025 =
-* Added 15+ filter and action hooks for complete data customization
-* REST response filtering for API extensibility
-
-= 1.0.2 - October 29, 2025 =
-* Performance improvements for memory usage and processing speed
-* Bug fixes for validation and error handling across all generators
-* Compatibility updates for latest EasyCommerce features
-
-= 1.0.0 - October 15, 2025 =
-* Real-time dependency checks via new REST controller
-* PHPStan level 8 compliance
-* Build system and documentation improvements
-
-= 0.9.0 - September 15, 2025 =
-* Initial release with 10 core generators
-* WordPress admin color integration
-* React 18 interface with real-time feedback
-* PSR-4 architecture with native EasyCommerce model integration
 
 == Upgrade Notice ==
 


### PR DESCRIPTION
Splits the changelog: `CHANGELOG.md` holds the full history, `readme.txt` keeps the four most recent releases and links out.

## Why this shape

The WordPress.org plugin handbook recommends it directly, under **File Size**:

> As for your changelog, we recommend keeping the current release in the readme and splitting the rest out out into it's own file — changelog.txt for example.

There is a hard limit behind the advice: the directory parser truncates `section-changelog` at **5,000 words** and raises a `trimmed_section_changelog` warning. Four releases is a comfortable margin.

## What reconstructing the history turned up

This was meant to be a move, but the existing changelog turned out to be incomplete and partly wrong.

**Three releases were tagged and shipped but never documented anywhere:**

| Version | Tagged | Was in changelog? |
|---|---|---|
| 1.0.1 | 2025-10-26 | No |
| 1.0.3 | 2025-10-29 | No |
| 2.0.4 | 2026-02-26 | No |

Their entries are derived from the commits in each tag range, not invented. Notably, every GitHub release back to v1.0.0 already says *"Refer to CHANGELOG.md for full details"* — pointing at a file that had never existed.

**Dates had drifted from their tags.** `CHANGELOG.md` uses the tag dates as authoritative:

| Version | readme.txt said | Tag | Drift |
|---|---|---|---|
| 1.0.0 | October 15, 2025 | 2025-10-26 | 11 days |
| 1.0.2 | October 29, 2025 | 2025-10-26 | 3 days |
| 2.0.2 | January 15, 2026 | 2026-01-14 | 1 day |
| 2.0.3 | January 15, 2026 | 2026-01-14 | 1 day |

There is even a historical commit titled *"fix(docs): correct release date from September to October in changelog"*, so this has been a recurring problem.

**One attribution corrected.** `readme.txt` credited the 15+ hook system to 1.0.4, but `feat: enhance plugin extensibility with comprehensive hook system` lands in the `v1.0.2..v1.0.3` range. It is now under 1.0.3, and 1.0.4 carries what it actually shipped — the locale sample dataset and deployment fixes. **Flagging this one explicitly in case you remember the release differently from what the commits show.**

## Format

`CHANGELOG.md` follows [Keep a Changelog **2.0.0**](https://keepachangelog.com/en/2.0.0/), published 2026-06-07 — worth noting since most guides still cite 1.1.0. Newest first, `YYYY-MM-DD` dates, only the six canonical headings, `- **Breaking:**` markers inside the relevant heading (used on 2.0.0's schema realignment), and compare links at the bottom.

0.9.0 predates tagging, so it has no comparison link and is deliberately unbracketed — a `## [0.9.0]` heading with no matching reference would render as literal `[0.9.0]`.

## readme.txt

Keeps 2.2.0, 2.1.0, 2.0.4, 2.0.3 above an **absolute** link to CHANGELOG.md. Absolute matters: readme.txt renders at `wordpress.org/plugins/…`, so a relative path resolves against wordpress.org and 404s. `[text](url)` survives the directory's kses allowlist, so the link renders.

`== Upgrade Notice ==` is untouched — WordPress core reads it for the update prompt.

## Keeping it from rotting

The convention is written into `CLAUDE.md` (agents), `CONTRIBUTING.md` (contributors), and the README changelog link. That section also records the readme.txt constraints that caused real bugs here: it is PHP Markdown Extra plus a kses allowlist, **not** GitHub-flavored markdown, so tables, images, ``` fences and `#` headings are silently stripped; version entries are `= 1.2.3 =`; and release dates come from the git tag.

The rule underneath: each fact lives in exactly one file. Duplicated history is what produced the drift and the three missing releases.

## Verification

- Official [WP.org readme validator](https://wordpress.org/plugins/developers/readme-validator/): no errors, no warnings
- All 13 compare/tag URLs return HTTP 200
- Every bracketed version heading has a matching reference link, and vice versa
- All 14 entries use only the six canonical headings and ISO dates
- Rendered through GitHub's markdown API — no literal `[x]` artifacts

## Follow-ups, not in this PR

- **`readme.txt` is ~15 KB**, above the handbook's ~10 KB guidance. The changelog trim removed roughly 3 KB but the external-services and source-code disclosures added more. The validator passes, so this is guidance rather than an error; trimming Description/FAQ/Screenshots would be a separate pass.
- **`Tested up to: 6.9`** still trails core 7.0.2, pending an actual compatibility test.
- **PHP Tests fail on trunk** across all five PHP versions, pre-existing and unrelated to docs.
