### PR TITLE
feat(preview): show up to 25 rows instead of 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Release dates are taken from the release tags in this repository. The [`readme.t
 - Order statuses `failed` and `partially_refunded`, and the cart status `payment_initiated`, all of which EasyCommerce added to its column definitions after the last sync.
 - Generated orders now carry the `billing_address`, `shipping_address`, `tax`, `shipping_tax`, `shipping_fee`, `shipping_method`, and `shipping_method_label` meta that EasyCommerce reads, so orders render complete in the admin and in the date-range reports.
 
+### Changed
+
+- The live preview now shows up to 25 rows instead of 12, matching what the preview endpoint already returns.
+
 ### Fixed
 
 - The transaction generator no longer produces the type `fee`, which is not in the `transactions.type` column and was discarded or rejected on write depending on SQL mode.

--- a/src/admin/components/generator/PreviewTable.tsx
+++ b/src/admin/components/generator/PreviewTable.tsx
@@ -21,6 +21,15 @@ interface PreviewTableProps {
   shuffleN: number;
 }
 
+/**
+ * Most rows the preview will render.
+ *
+ * Matches the server-side ceiling in Generator::preview(), which clamps to 25.
+ * Asking for more would render fewer rows than the footer claims, so raising
+ * this means raising that too.
+ */
+const MAX_PREVIEW_ROWS = 25;
+
 const KIND_CLASS: Record<string, string> = {
   mono: "cell-mono",
   money: "cell-money",
@@ -64,7 +73,7 @@ export function PreviewTable({
   locale,
   shuffleN,
 }: PreviewTableProps) {
-  const visible = Math.min(count, 12);
+  const visible = Math.min(count, MAX_PREVIEW_ROWS);
 
   const [columns, setColumns] = useState<PreviewColumn[]>([]);
   const [rows, setRows] = useState<Record<string, PreviewCell>[]>([]);


### PR DESCRIPTION
The preview table was capped at 12 rows on the client while the server already returned up to 25 — so a third of every response was fetched, then thrown away.

| Layer | Cap | Where |
|---|---|---|
| Client | 12 | `PreviewTable.tsx:67` — `Math.min(count, 12)` |
| Server | 25 | `Generator.php:452` — `max(1, min(25, $count))` |

Raised the client cap to 25 to match, and named the constant with a note that the two ceilings have to move together — if they drift apart again, the footer's "showing N of M" starts lying.

Worth noting this only became useful after #14: with the preview card unable to scroll, extra rows would have been clipped by the card anyway. That's likely why the low cap went unnoticed.

## If you want more than 25

Both ceilings have to move. The server clamp exists as a guard — preview rows are generated one at a time through the full faker path, so cost scales with the count, and the heavier generators (Products with variations, Orders with items) are the ones that would feel it. Happy to raise both if you have a number in mind; I didn't want to lift a deliberate backend guard without asking.

## Testing

`yarn build` compiles clean. Verified in the emitted bundle: `Math.min(r,25)` present, no remaining 12-cap.

Not visually confirmed — the dev site only resolves on the Linux side and Chrome is on Windows. Your `yarn start` watcher will pick this up once merged and pulled; set a generator's count above 12 and the table should fill and scroll.

One-line behaviour change, no logic or markup restructuring.
