### PR TITLE
fix(api): stop reporting success when every generated item failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Release dates are taken from the release tags in this repository. The [`readme.t
 
 ### Fixed
 
+- A batch where every item failed reported success. Generation now returns the underlying reason instead of "0 items successfully created", and a partly successful batch reports how many items could not be created and why.
+
 - The transaction generator no longer produces the type `fee`, which is not in the `transactions.type` column and was discarded or rejected on write depending on SQL mode.
 - Product variations generated from the Products generator now populate their attribute rows. The payload used key names EasyCommerce does not read, so no variation attributes were ever stored.
 - Variations created by the Product Variations generator are assigned a sequential per-product price identifier instead of all sharing the default, which previously made order items resolve to an arbitrary variation.

--- a/includes/Abstracts/Controller.php
+++ b/includes/Abstracts/Controller.php
@@ -245,12 +245,37 @@ abstract class Controller extends WP_REST_Controller {
 		}
 
 		$total_output = count( $result );
+		$errors       = $generator->get_generation_errors();
+
+		// Items may fail individually without aborting the batch. If none survived,
+		// the request did not succeed, and answering 200 with "0 items created"
+		// hides a reason the generator already took the trouble to explain.
+		if ( 0 === $total_output && ! empty( $errors ) ) {
+			return new WP_Error(
+				'generation_failed',
+				$errors[0],
+				array(
+					'status' => 500,
+					'errors' => array_values( array_unique( $errors ) ),
+				)
+			);
+		}
+
+		$failed = count( $errors );
 
 		$message = sprintf(
 			// translators: Total output.
 			_n( '%1$s item successfully created.', '%1$s items successfully created.', $total_output, 'easycommerce-fakerpress' ),
 			$total_output
 		);
+
+		if ( $failed > 0 ) {
+			$message .= ' ' . sprintf(
+				// translators: %s: number of items that could not be created.
+				_n( '%s could not be created.', '%s could not be created.', $failed, 'easycommerce-fakerpress' ),
+				$failed
+			);
+		}
 
 		/**
 		 * Filters the success message returned by the REST API generation endpoint.
@@ -271,6 +296,13 @@ abstract class Controller extends WP_REST_Controller {
 			'message'                  => $message,
 			$this->get_resource_type() => $result,
 		);
+
+		// Only present on a partial batch, so existing clients see an unchanged
+		// response shape whenever everything succeeded.
+		if ( $failed > 0 ) {
+			$response['failed'] = $failed;
+			$response['errors'] = array_values( array_unique( $errors ) );
+		}
 
 		/**
 		 * Filters the REST API response data.

--- a/includes/Abstracts/Generator.php
+++ b/includes/Abstracts/Generator.php
@@ -100,6 +100,33 @@ abstract class Generator {
 	protected array $generation_params = array();
 
 	/**
+	 * Failure messages collected during the last generate() call.
+	 *
+	 * Individual items are allowed to fail without aborting the batch, but the
+	 * reason has to survive the loop — otherwise a batch where every item failed
+	 * is indistinguishable from a batch that was never asked to do anything, and
+	 * the caller reports success for zero rows.
+	 *
+	 * @since 2.3.0
+	 * @var array<int, string>
+	 */
+	protected array $generation_errors = array();
+
+	/**
+	 * Get the failures collected during the last generate() call.
+	 *
+	 * Reset at the start of every generate(), so it always describes the most
+	 * recent batch. Empty when every item succeeded.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @return array<int, string> Failure messages, in the order they occurred.
+	 */
+	public function get_generation_errors(): array {
+		return $this->generation_errors;
+	}
+
+	/**
 	 * Constructor
 	 *
 	 * Initializes the generator with a reference to the WordPress database object.
@@ -263,7 +290,8 @@ abstract class Generator {
 			$this->log( "Seeded Faker with value: {$seed}", 'info' );
 		}
 
-		$results = array();
+		$results                 = array();
+		$this->generation_errors = array();
 
 		try {
 			for ( $i = 0; $i < $count; $i++ ) {
@@ -283,6 +311,7 @@ abstract class Generator {
 
 					if ( is_wp_error( $item_result ) ) {
 						$this->log( 'Single item generation failed: ' . $item_result->get_error_message(), 'warning' );
+						$this->generation_errors[] = $item_result->get_error_message();
 						continue;
 					}
 
@@ -320,6 +349,7 @@ abstract class Generator {
 					do_action( "easycommerce_fakerpress_after_generate_single_item_{$resource_type}", $item_result, $i );
 				} catch ( Exception $e ) {
 					$this->log( "Per-item exception: {$e->getMessage()}", 'error' );
+					$this->generation_errors[] = $e->getMessage();
 					continue;
 				}
 			}

--- a/src/admin/components/Pages/GeneratorPage.tsx
+++ b/src/admin/components/Pages/GeneratorPage.tsx
@@ -160,7 +160,12 @@ export default function GeneratorPage() {
           data: body,
         })) as GeneratorResult;
 
-        recordRun(generator.route, count, true, data.message ?? "", {
+        // Items can fail individually without failing the request, so report
+        // what was actually created rather than what was asked for.
+        const failed = data.failed ?? 0;
+        const created = Math.max(0, count - failed);
+
+        recordRun(generator.route, created, true, data.message ?? "", {
           locale,
           seed,
         });
@@ -168,10 +173,19 @@ export default function GeneratorPage() {
           sprintf(
             /* translators: %1$s: count, %2$s: generator name */
             __("Generated %1$s %2$s", "easycommerce-fakerpress"),
-            count.toLocaleString(),
+            created.toLocaleString(),
             generatorLabel,
           ),
-          __("Added to your EasyCommerce store", "easycommerce-fakerpress"),
+          failed > 0
+            ? sprintf(
+                /* translators: %s: number of items that could not be created */
+                __(
+                  "%s could not be created — see the run details.",
+                  "easycommerce-fakerpress",
+                ),
+                failed.toLocaleString(),
+              )
+            : __("Added to your EasyCommerce store", "easycommerce-fakerpress"),
         );
       } catch (err) {
         const errMsg =

--- a/src/admin/types/index.ts
+++ b/src/admin/types/index.ts
@@ -52,6 +52,10 @@ export interface Generator {
 export interface GeneratorResult {
   message: string;
   generated?: number;
+  /** Present only when some items in the batch could not be created. */
+  failed?: number;
+  /** Distinct reasons the failed items gave, present alongside `failed`. */
+  errors?: string[];
   [key: string]: any;
 }
 


### PR DESCRIPTION
A request for 50 items where all 50 failed answered **HTTP 200 with "0 items successfully created."**

Items are allowed to fail individually without aborting the batch — that part is deliberate. The bug is that the reason didn't survive the loop:

- `Generator::generate()` logged each `WP_Error` and `continue`d **without collecting it** (`Abstracts/Generator.php:284`)
- it returned only the successes
- `Controller::generate_items()` checked `is_wp_error()` on that array — **false for an empty array** — and fell through to counting (`Abstracts/Controller.php:240`)

The Refund generator is the clearest victim. It returns a `WP_Error` explaining that completed or processing orders have to exist first; the user got a green success toast instead of that sentence.

PHPStan couldn't catch it either — `phpstan.neon:121-122` explicitly suppresses `should return … but returns false` and `has invalid return type …WP_Error`.

## Fix

Generators collect failures in `$generation_errors`, exposed via `get_generation_errors()` and reset at the start of every `generate()`. The controller then:

- returns a `WP_Error` carrying the first real reason when **nothing** was created
- on a **partial** batch, adds `failed` and `errors` to the response and appends "N could not be created" to the message

Both keys are omitted when everything succeeds, so **a fully successful response keeps its existing shape** — no client breakage.

The admin now reports what was actually created rather than what was requested, and names the shortfall. Previously a 50-item request that made 30 still toasted "Generated 50".

## Behaviour

| Case | Before | After |
|---|---|---|
| All succeed | `200` · "5 items successfully created." | unchanged |
| Partial (3 of 5) | `200` · "**5** items successfully created." | `200` · "3 items successfully created. 2 could not be created." + `failed`, `errors` |
| All fail | `200` · "0 items successfully created." | `500` · `WP_Error` with the generator's own message |
| Count 0 | `200` · "0 items…" | unchanged |

## Testing

`php -l` clean on both changed PHP files; `yarn build` compiles clean.

I could not run PHPUnit — `vendor/` is absent in this worktree, and the suite self-skips without EasyCommerce anyway. Instead I extracted the new branch logic into a standalone script and ran all four cases above; the table is its actual output, not a description of intent.

Not exercised against a live store. The high-value manual check is running the Refund generator on a store with no completed orders — that should now show the real message instead of a success toast.

## Related

This was the top finding from the gap audit. The audit also flagged that no e2e test ever clicks Generate, which is why a regression this visible survived — worth a follow-up.
