### PR TITLE
fix(release): correct the WordPress floor and stop shipping dev files

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -14,6 +14,12 @@
 # Compiled output lives in build/ which ships; raw source does not.
 /src/
 
+# Build-time font sources. Only src/styles.css imports these, and webpack
+# emits its own hashed copies into build/fonts/, which is what build/app.css
+# resolves. Shipping them too duplicated ~356 KB for nothing.
+# assets/brand/ is NOT excluded — it is read at runtime for the menu icon.
+/assets/fonts/
+
 # ── Documentation (GitHub-only) ───────────────────────────────
 # readme.txt is the canonical WP.org doc; .md files are for GitHub.
 *.md
@@ -29,7 +35,7 @@ yarn.lock
 webpack.config.js
 postcss.config.js
 tsconfig.json
-.eslintrc.js
+eslint.config.mjs
 .eslintcache
 .stylelintrc.js
 .stylelintcache

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -3,7 +3,7 @@
   "landingPage": "/wp-admin/admin.php?page=easycommerce-fakerpress",
   "preferredVersions": {
     "php": "8.3",
-    "wp": "6.8"
+    "wp": "6.9"
   },
   "phpExtensionBundles": [
     "kitchen-sink"
@@ -41,7 +41,7 @@
       "step": "setSiteOptions",
       "options": {
         "blogname": "EasyCommerce FakerPress Demo",
-        "blogdescription": "Experience the power of realistic ecommerce data generation with v2.1.1 enhancements",
+        "blogdescription": "Experience the power of realistic ecommerce data generation",
         "admin_email": "demo@example.com",
         "start_of_week": "1",
         "use_balanceTags": "0",
@@ -93,12 +93,12 @@
     },
     {
       "step": "runPHP",
-      "code": "<?php\n// Add welcome notice and helpful tips\nupdate_option('easycommerce_fakerpress_demo_notice', [\n    'type' => 'info',\n    'message' => 'Welcome to EasyCommerce FakerPress Demo v2.1.1! This environment is pre-configured with EasyCommerce plugin and sample data structures. Visit the FakerPress admin page to start generating realistic ecommerce data, including enhanced shipping plans with quantity-based calculations and improved regional coverage.',\n    'dismissible' => true\n]);\n\n// Set up demo-friendly admin settings\nupdate_option('show_on_front', 'posts');\nupdate_option('posts_per_page', 10);\nupdate_option('default_comment_status', 'open');\nupdate_option('default_ping_status', 'open');\n\n// Create a sample menu\n$menu_id = wp_create_nav_menu('Main Menu');\nif (!is_wp_error($menu_id) && $menu_id) {\n    // Add pages to menu\n    $pages = ['shop', 'cart', 'checkout', 'my-account'];\n    $menu_order = 1;\n    \n    foreach ($pages as $page_slug) {\n        $page = get_page_by_path($page_slug);\n        if ($page) {\n            wp_update_nav_menu_item($menu_id, 0, [\n                'menu-item-title' => $page->post_title,\n                'menu-item-object' => 'page',\n                'menu-item-object-id' => $page->ID,\n                'menu-item-type' => 'post_type',\n                'menu-item-status' => 'publish',\n                'menu-item-position' => $menu_order++\n            ]);\n        }\n    }\n    \n    // Assign menu to primary location\n    $locations = get_theme_mod('nav_menu_locations', []);\n    $locations['primary'] = $menu_id;\n    set_theme_mod('nav_menu_locations', $locations);\n}\n\n// Generate sample shipping plans using FakerPress if available\ndefine('ABSPATH', true); // Ensure WP is loaded\nif (class_exists('EasyCommerceFakerPress\\Generators\\Shipping_Plan')) {\n    require_once ABSPATH . 'wp-content/plugins/easycommerce-fakerpress/includes/Abstracts/Generator.php';\n    $generator = new EasyCommerceFakerPress\\Generators\\Shipping_Plan();\n    $results = $generator->generate_multiple(3, []);\n    if (!empty($results)) {\n        update_option('easycommerce_fakerpress_sample_shipping_plans', $results);\n        echo 'Sample shipping plans generated! ';\n    }\n}\n\necho 'Demo environment fully configured! Ready for EasyCommerce FakerPress testing.';"
+      "code": "<?php\n// Add welcome notice and helpful tips\nupdate_option('easycommerce_fakerpress_demo_notice', [\n    'type' => 'info',\n    'message' => 'Welcome to EasyCommerce FakerPress Demo! This environment is pre-configured with EasyCommerce plugin and sample data structures. Visit the FakerPress admin page to start generating realistic ecommerce data, including enhanced shipping plans with quantity-based calculations and improved regional coverage.',\n    'dismissible' => true\n]);\n\n// Set up demo-friendly admin settings\nupdate_option('show_on_front', 'posts');\nupdate_option('posts_per_page', 10);\nupdate_option('default_comment_status', 'open');\nupdate_option('default_ping_status', 'open');\n\n// Create a sample menu\n$menu_id = wp_create_nav_menu('Main Menu');\nif (!is_wp_error($menu_id) && $menu_id) {\n    // Add pages to menu\n    $pages = ['shop', 'cart', 'checkout', 'my-account'];\n    $menu_order = 1;\n    \n    foreach ($pages as $page_slug) {\n        $page = get_page_by_path($page_slug);\n        if ($page) {\n            wp_update_nav_menu_item($menu_id, 0, [\n                'menu-item-title' => $page->post_title,\n                'menu-item-object' => 'page',\n                'menu-item-object-id' => $page->ID,\n                'menu-item-type' => 'post_type',\n                'menu-item-status' => 'publish',\n                'menu-item-position' => $menu_order++\n            ]);\n        }\n    }\n    \n    // Assign menu to primary location\n    $locations = get_theme_mod('nav_menu_locations', []);\n    $locations['primary'] = $menu_id;\n    set_theme_mod('nav_menu_locations', $locations);\n}\n\n// Generate sample shipping plans using FakerPress if available\nif (class_exists('EasyCommerceFakerPress\\Generators\\Shipping_Plan')) {\n    $generator = new EasyCommerceFakerPress\\Generators\\Shipping_Plan();\n    $results = $generator->generate_multiple(3, []);\n    if (!empty($results)) {\n        update_option('easycommerce_fakerpress_sample_shipping_plans', $results);\n        echo 'Sample shipping plans generated! ';\n    }\n}\n\necho 'Demo environment fully configured! Ready for EasyCommerce FakerPress testing.';"
     }
   ],
   "meta": {
-    "title": "EasyCommerce FakerPress Demo v2.1.1",
-    "description": "Experience the comprehensive EasyCommerce FakerPress plugin with 10 specialized data generators, modern React interface, and realistic ecommerce data generation, featuring enhanced shipping plan capabilities.",
+    "title": "EasyCommerce FakerPress Demo",
+    "description": "Experience the comprehensive EasyCommerce FakerPress plugin with 14 specialized data generators, modern React interface, and realistic ecommerce data generation, featuring enhanced shipping plan capabilities.",
     "author": "Al Amin Ahamed",
     "categories": [
       "ecommerce",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,16 @@ Release dates are taken from the release tags in this repository. The [`readme.t
 
 ### Changed
 
+- **Breaking:** The minimum WordPress version is now 6.6, corrected from 5.0. The admin app depends on the `react-jsx-runtime` script handle that core registers in 6.6, and the `Requires Plugins` header needs 6.5, so the old floor was never accurate — the plugin could not run on it.
 - New brand mark: a shopping bag holding rows of generated data, replacing the sparkle. Applied to the WordPress.org icon and banners, the admin menu icon, the sidebar, and the logo lockup.
 - The live preview now shows up to 25 rows instead of 12, matching what the preview endpoint already returns.
 
 ### Fixed
 
 - A batch where every item failed reported success. Generation now returns the underlying reason instead of "0 items successfully created", and a partly successful batch reports how many items could not be created and why.
-
+- Right-to-left admin languages now get the right-to-left stylesheet, which was built on every release but never loaded.
+- The development ESLint config and the build-time font sources no longer ship in the plugin package.
+- The WordPress Playground demo no longer advertises a version that was never released, and its setup step no longer emits a PHP warning.
 - The transaction generator no longer produces the type `fee`, which is not in the `transactions.type` column and was discarded or rejected on write depending on SQL mode.
 - Product variations generated from the Products generator now populate their attribute rows. The payload used key names EasyCommerce does not read, so no variation attributes were ever stored.
 - Variations created by the Product Variations generator are assigned a sequential per-product price identifier instead of all sharing the default, which previously made order items resolve to an arbitrary variation.

--- a/class-easycommerce-fakerpress.php
+++ b/class-easycommerce-fakerpress.php
@@ -341,6 +341,10 @@ class EasyCommerce_FakerPress {
 			$version
 		);
 
+		// The build already emits build/app-rtl.css; without this WordPress never
+		// swaps to it and right-to-left admins get the left-to-right sheet.
+		wp_style_add_data( 'easycommerce-fakerpress-admin', 'rtl', 'replace' );
+
 		// Add CSS variables for admin colors.
 		$css_vars = sprintf(
 			':root { --wp-admin-primary: %s; --wp-admin-secondary: %s; --wp-admin-highlight: %s; --wp-admin-accent: %s; }',

--- a/easycommerce-fakerpress.php
+++ b/easycommerce-fakerpress.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://github.com/mralaminahamed/easycommerce-fakerpress
  * Description:       Create realistic test data for your EasyCommerce store in seconds! Generate products, customers, orders, coupons and more with our intuitive admin interface. Perfect for development, testing, and demos. Features smart defaults, real-time validation, and seamless WordPress integration.
  * Version:           2.2.0
- * Requires at least: 5.0
+ * Requires at least: 6.6
  * Requires PHP:      7.4
  * Requires Plugins:  easycommerce
  * Author:            Al Amin Ahamed

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === EasyCommerce FakerPress ===
 Contributors: mralaminahamed
 Tags: ecommerce, faker, data-generation, testing, development
-Requires at least: 5.0
+Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 7.4
 Requires Plugins: easycommerce
@@ -115,7 +115,7 @@ Build tooling: webpack (via @wordpress/scripts), TypeScript, and Tailwind CSS. C
 5. Access via the EC FakerPress menu.
 
 = Requirements =
-* WordPress 5.0+
+* WordPress 6.6+
 * PHP 7.4+ (8.0+ recommended)
 * EasyCommerce plugin (must be active)
 * 256MB memory minimum (512MB recommended for large datasets)


### PR DESCRIPTION
Four release-readiness defects from the gap audit.

## 1. `Requires at least: 5.0` was false — the plugin cannot run on 5.0

Two independent proofs:

- `build/app.asset.php` declares a **`react-jsx-runtime`** dependency. Core first registers that script handle in **6.6**.
- The `Requires Plugins: easycommerce` header is only honoured from **6.5** — on older cores the dependency gate silently does nothing.

So on WP 5.0 the admin app enqueues against a handle that doesn't exist and never mounts, while the EasyCommerce requirement isn't enforced at all. Corrected to **6.6** in the plugin header, `readme.txt:4`, and the "WordPress 5.0+" bullet at `readme.txt:118`.

Marked **Breaking** in the changelog — it raises the stated floor, even though no install that actually worked is affected.

## 2. The ESLint config was shipping to users

`.distignore` excluded `.eslintrc.js` — a filename this repo has never used. The real flat config is `eslint.config.mjs`, unmatched and packaged.

## 3. 356 KB of fonts shipped twice

`assets/fonts/` is imported only by `src/styles.css`, and `/src/` is excluded. Webpack emits its own hashed copies into `build/fonts/`, which is what `build/app.css` actually resolves — so the woff2 files shipped a second time for nothing.

`assets/brand/` is **not** excluded: the menu icon is read from it at runtime by `get_menu_icon()`.

## 4. RTL admins got the LTR stylesheet

`build/app-rtl.css` was produced by every build and never loaded. `wp_style_add_data( …, 'rtl', 'replace' )` makes WordPress swap it. One line.

## Plus: the Playground blueprint

It advertised "Demo **v2.1.1**" — a version that was never released, absent from `CHANGELOG.md` and from `git tag` — and "**10** specialized data generators" when there are 14. Its final step also ran `define('ABSPATH', true)`, which warns on PHP 8 and does nothing, followed by a `require_once` Composer's autoloader already handles. `preferredVersions.wp` moved 6.8 → 6.9 to track `Tested up to`.

## Testing

`php -l` clean on both changed PHP files. Blueprint re-parsed with `json.loads` after editing — still valid, and zero `2.1.1` references remain.

I simulated the deploy filter with `rsync --exclude-from=.distignore` and checked the result rather than trusting the pattern:

```
eslint.config.mjs shipped? no
assets/fonts shipped?     no
assets/brand shipped?     yes-good
build/ shipped?           yes-good
package size: 1.4M   (was 1.7M)
```

## Deliberately not touched

- **`Tested up to: 6.9`** still trails core 7.0.2. Bumping it asserts compatibility I haven't verified — it needs a real smoke test on 7.0, not a text edit.
- **The stale `.pot`** (`POT-Creation-Date: 2026-03-17`, zero `src/` references) needs `composer makepot`, which needs `vendor/`. It doesn't affect the shipped zip — the deploy workflow regenerates it — so it's a contributor-facing annoyance, not a release blocker.
