### PR TITLE
fix(ui): let headings follow the active theme

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -145,6 +145,19 @@ body:not(.admin-bar) .fp-root { --fp-admin-bar: 0px; }
 
 .fp-root *, .fp-root *::before, .fp-root *::after { box-sizing: border-box; }
 
+/* WordPress core hard-codes a near-black on bare headings in
+   wp-admin/css/common.css (`h1 { color: #1d2327 }`, and the same for h3 and
+   h6). An element selector always beats an inherited value, so those headings
+   ignored the themed colour set on .fp-root and stayed dark-on-dark once the
+   dark theme was active. Handing them back to inheritance lets them follow
+   --text in whichever theme is showing. */
+.fp-root h1,
+.fp-root h2,
+.fp-root h3,
+.fp-root h4,
+.fp-root h5,
+.fp-root h6 { color: inherit; }
+
 .fp-root[data-theme="dark"] {
   --bg: oklch(0.165 0.011 270);
   --bg-2: oklch(0.145 0.011 270);


### PR DESCRIPTION
Page titles were dark-on-dark in the dark theme — effectively invisible on Overview, Settings, and Our Plugins.

## Cause

WordPress core hard-codes a near-black on **bare heading elements** in `wp-admin/css/common.css`:

```css
h1 { color: #1d2327; }   /* line 339 — same for h3 and h6 */
```

`.fp-root` sets `color: var(--text)`, but that only reaches headings by *inheritance* — and **an element selector always beats an inherited value**, regardless of how specific the ancestor's selector was. So `<h1 className="fp-h1">` resolved to `#1d2327` no matter which theme was active. `.fp-h1` only sets size and weight, never colour, so nothing overrode it.

It went unnoticed in the light theme because near-black on near-white is exactly what you'd want.

## Fix

```css
.fp-root h1, .fp-root h2, … .fp-root h6 { color: inherit; }
```

`0-1-1` beats core's `0-0-1`, and `inherit` hands the headings back to `--text` so they track whichever theme is showing. Two declarations, no markup change.

## Verified

Rendered core's rule and the plugin's together, with and without the reset, rather than reasoning about specificity and hoping:

| | Result |
|---|---|
| Without the reset | heading resolves to `#1d2327` on the dark surface — unreadable |
| With the reset | heading resolves to `--text` — legible |

`yarn build` compiles clean and the rule is present in the emitted `build/app.css`:

```
.fp-root h1,.fp-root h2,.fp-root h3,.fp-root h4,.fp-root h5,.fp-root h6{color:inherit}
```

## Checked and deliberately left alone

Core also colours bare `<a>` with `#2271b1`. There are three unclassed anchors in `SettingsPage.tsx:456-466`, but each wraps a `<Button>` that sets its own colour, so the anchor colour never renders. No change needed.

Not yet seen in a real WordPress admin — the dev site doesn't resolve from this environment. Worth toggling to the dark theme once pulled.
