### PR TITLE
chore: declare compatibility with WordPress 7.0

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -3,7 +3,7 @@
   "landingPage": "/wp-admin/admin.php?page=easycommerce-fakerpress",
   "preferredVersions": {
     "php": "8.3",
-    "wp": "6.9"
+    "wp": "7.0"
   },
   "phpExtensionBundles": [
     "kitchen-sink"

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mralaminahamed
 Tags: test data, dummy data, sample data, demo content, faker
 Requires at least: 6.6
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 Requires Plugins: easycommerce
 Stable tag: 2.2.0


### PR DESCRIPTION
`Tested up to` had trailed core by two branches (6.9 vs 7.0.2). Bumped to **7.0** — after actually exercising the plugin, not by editing the number.

## Checked against the 7.0 field guide

The [WordPress 7.0 Field Guide](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/) lists four changes that break plugins. None reach this one:

| Breaking change | Applies? |
|---|---|
| Iframed editor enforcement for Block API v3 | **No** — registers no blocks (`register_block_type` absent; the only `block.json` files are PHPUnit fixtures in `vendor/`) |
| DataViews `groupByField` → `groupBy` object | **No** — no `WP_List_Table` or DataViews usage anywhere |
| Interactivity API `effect()` → `watch()` | **No** — doesn't use the Interactivity API |
| PHP 7.2/7.3 dropped | **No** — already requires PHP 7.4 |

## Verified on a real WordPress 7.0

Booted a clean WP 7.0 in WordPress Playground with EasyCommerce installed:

- Plugin **activates** and the dependency gate passes
- Admin **renders in full** — sidebar with all 14 generators, dashboard, stat cards, sparklines
- **Live preview works** — a real REST request to the preview route returning 10 generated product rows
- No PHP notices or warnings on screen

## Verified again on WordPress 7.1-beta2

Your local install, via WP-CLI:

- All **29 REST routes** register under `easycommerce-fakerpress/v1`
- A product **generates end to end** and is written to the database (test record removed afterwards)
- **Zero WordPress core deprecations** raised by this plugin

The blueprint's `preferredVersions.wp` moves 6.9 → 7.0 to match.

## Two things found along the way — neither blocking, both worth a follow-up

**1. 178 deprecated FakerPHP property accesses in our generators.** Every generation run emits deprecation notices like:

```
Since fakerphp/faker 1.14: Accessing property "company" is deprecated, use "company()" instead.
```

Concentrated in `->city` (70) and `->postcode` (64), plus 15 other providers across the generators. This is version-independent — it happens on any WordPress — and it fills debug logs on every run. Mechanical to fix (append `()`), but it's 178 sites across many files, so it deserves its own PR rather than riding along here.

**2. A historical fatal in the local debug log**, from 24 June:

```
Call to undefined method EasyCommerce\Models\Order::get_order_number()
  in includes/Generators/Order.php:223
```

Already fixed — removed in `5e1e3a6`, zero remaining call sites, and no recurrence in a log written as recently as today. Noting it only so it isn't rediscovered as a live bug.

## Note

Merging publishes to the live WordPress.org listing, and the `Tested up to` value is what removes the "untested with your version of WordPress" warning for 7.0 users.
