### PR TITLE
fix(orders): spread order dates over time, and repair order generation

### DIFF
--- a/includes/Controllers/Order.php
+++ b/includes/Controllers/Order.php
@@ -75,6 +75,14 @@ class Order extends Controller {
 	 */
 	protected function get_resource_specific_params(): array {
 		return array(
+			'date_range_days'           => array(
+				'description'       => __( 'Spread order dates over this many days back from today. 0 dates every order today.', 'easycommerce-fakerpress' ),
+				'type'              => 'integer',
+				'minimum'           => 0,
+				'maximum'           => 1825,
+				'default'           => 90,
+				'sanitize_callback' => 'absint',
+			),
 			'order_status'              => array(
 				'description'       => __( 'Order status distribution.', 'easycommerce-fakerpress' ),
 				'type'              => 'string',

--- a/includes/Generators/Order.php
+++ b/includes/Generators/Order.php
@@ -126,7 +126,11 @@ class Order extends Generator {
 
 		// Get the customer billing address early for tax calculation.
 		$customer_model  = new CustomerModel( $customer['id'] );
-		$billing_address = ! empty( $customer_model->get_billing_address() ) ? $customer_model->get_billing_address() : $this->generate_fallback_address( $customer );
+		$billing_address = $this->normalize_address( $customer_model->get_billing_address() );
+
+		if ( empty( $billing_address ) ) {
+			$billing_address = $this->generate_fallback_address( $customer );
+		}
 
 		// Convert variations to order items format required by EasyCommerce.
 		$order_items = $this->convert_variations_to_items( $variations, $billing_address );
@@ -248,6 +252,8 @@ class Order extends Generator {
 			return new WP_Error( 'order_creation_failed', __( 'Failed to create order using EasyCommerce model.', 'easycommerce-fakerpress' ) );
 		}
 
+		$order_date = $this->backdate_order( (int) $order->get_id() );
+
 		// Update customer statistics.
 		$this->update_customer_stats( $customer['id'], $total );
 
@@ -264,7 +270,7 @@ class Order extends Generator {
 			'discount_amount'  => isset( $order_meta['coupon_details']['discount'] ) ? $order_meta['coupon_details']['discount'] : 0,
 			'currency'         => 'USD',
 			'payment_method'   => isset( $order_meta['payment_details']['method'] ) ? $order_meta['payment_details']['method'] : '',
-			'order_date'       => current_time( 'Y-m-d H:i:s' ),
+			'order_date'       => $order_date,
 			'items'            => $this->format_order_items_for_result( $order_items ),
 			'billing_address'  => isset( $order_meta['addresses']['billing'] ) ? $order_meta['addresses']['billing'] : array(),
 			'shipping_address' => isset( $order_meta['addresses']['shipping'] ) ? $order_meta['addresses']['shipping'] : array(),
@@ -635,7 +641,11 @@ class Order extends Generator {
 	 */
 	private function generate_order_meta( array $customer, float $subtotal, array $billing_address ): array {
 		$customer_model   = new CustomerModel( $customer['id'] );
-		$shipping_address = ! empty( $customer_model->get_shipping_address() ) ? $customer_model->get_shipping_address() : $billing_address;
+		$shipping_address = $this->normalize_address( $customer_model->get_shipping_address() );
+
+		if ( empty( $shipping_address ) ) {
+			$shipping_address = $billing_address;
+		}
 
 		return array(
 			'addresses'        => array(
@@ -663,6 +673,104 @@ class Order extends Generator {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Coerce a stored address into an array.
+	 *
+	 * Customer addresses come back through EasyCommerce's get_meta(), which
+	 * returns whatever get_user_meta() unserialises — and a customer whose
+	 * address was saved at checkout gets a stdClass, not an array. Both
+	 * convert_variations_to_items() and generate_order_meta() declare `array`
+	 * parameters, so passing that object straight through raised an uncaught
+	 * TypeError and no order could be generated at all for such a customer.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param mixed $address Address value as stored, of any shape.
+	 *
+	 * @return array<string, mixed> The address as an array, empty if unusable.
+	 */
+	private function normalize_address( $address ): array {
+		if ( is_object( $address ) ) {
+			$address = (array) $address;
+		}
+
+		if ( ! is_array( $address ) ) {
+			return array();
+		}
+
+		foreach ( $address as $key => $value ) {
+			if ( is_object( $value ) ) {
+				$address[ $key ] = (array) $value;
+			}
+		}
+
+		return $address;
+	}
+
+	/**
+	 * Spread the order back over time.
+	 *
+	 * EasyCommerce's Order::create() stamps created_at with current_time() and
+	 * takes no date argument, so every generated order lands on the day it was
+	 * generated. Every report in the admin is date-range driven, which turned a
+	 * whole generated catalogue into a single spike and made the reports
+	 * impossible to exercise. The only way to place an order in the past is to
+	 * correct the row after the insert.
+	 *
+	 * Dates are weighted towards the recent end, which is what a growing store
+	 * looks like, and the time of day is business-hours biased rather than
+	 * uniform across midnight.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param int $order_id Order ID to backdate.
+	 *
+	 * @return string The applied date in 'Y-m-d H:i:s', or the current time if
+	 *                backdating was disabled or the update failed.
+	 */
+	private function backdate_order( int $order_id ): string {
+		$now  = current_time( 'Y-m-d H:i:s' );
+		$days = isset( $this->generation_params['date_range_days'] )
+			? (int) $this->generation_params['date_range_days']
+			: 90;
+
+		// 0 keeps the model's own timestamp, for callers who want "all today".
+		if ( $days < 1 || $order_id < 1 ) {
+			return $now;
+		}
+
+		// Squaring a 0..1 random biases towards 0, i.e. towards today.
+		$fraction    = $this->get_faker()->randomFloat( 4, 0, 1 ) ** 2;
+		$days_back   = (int) round( $fraction * ( $days - 1 ) );
+		$hour        = (int) $this->get_faker()->numberBetween( 8, 21 );
+		$minute      = (int) $this->get_faker()->numberBetween( 0, 59 );
+		$second      = (int) $this->get_faker()->numberBetween( 0, 59 );
+		$timestamp   = strtotime( "-{$days_back} days", strtotime( $now ) );
+		$order_date  = gmdate( 'Y-m-d', $timestamp ) . sprintf( ' %02d:%02d:%02d', $hour, $minute, $second );
+
+		$table = $this->wpdb->prefix . 'ec_orders';
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->update(
+			$table,
+			array(
+				'created_at' => $order_date,
+				'updated_at' => $order_date,
+			),
+			array( 'id' => $order_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		if ( false === $updated ) {
+			$this->log( "Could not backdate order {$order_id}; it keeps today's date.", 'warning' );
+			return $now;
+		}
+
+		return $order_date;
 	}
 
 	/**

--- a/src/admin/lib/generators.ts
+++ b/src/admin/lib/generators.ts
@@ -230,6 +230,13 @@ export const generators: Generator[] = [
     route: "orders",
     popular: true,
     parameterConfig: {
+      date_range_days: {
+        description: __("Spread order dates over this many days back (0 = all today)", "easycommerce-fakerpress"),
+        type: "integer",
+        minimum: 0,
+        maximum: 1825,
+        default: 90,
+      },
       order_status: {
         description: __("Order status distribution", "easycommerce-fakerpress"),
         type: "string",


### PR DESCRIPTION
You asked for order backdating. Getting there uncovered that **order generation was fataling outright**, so this PR carries both — the crash had to be fixed before backdating could be verified at all.

## 1. Order generation was broken on trunk

```
Uncaught TypeError: convert_variations_to_items(): Argument #2 ($billing_address)
must be of type array, stdClass given — Order.php:132
```

Customer addresses come back through EasyCommerce's `get_meta()`, which returns whatever `get_user_meta()` unserialises. A customer whose address was saved at checkout gets a **stdClass**, but `convert_variations_to_items()` and `generate_order_meta()` both declare `array` parameters.

Worse: **`TypeError` extends `Error`, not `Exception`**, so the per-item `catch ( Exception $e )` in `Generator::generate()` doesn't catch it. The whole batch dies mid-run rather than skipping one item — which is also how a partially-completed run left an orphaned order behind during my testing.

I confirmed this reproduces on **clean trunk** before touching anything, so it isn't something I introduced.

`normalize_address()` now coerces either shape to an array, applied to billing *and* shipping (both had the flaw).

## 2. Backdating

`Order::create()` stamps `created_at` with `current_time()` and takes no date argument, so the row has to be corrected after insert. Orders now spread across a configurable window via a new **`date_range_days`** parameter (default 90, max 1825, `0` keeps every order on today).

Dates are weighted toward recent — squaring a 0–1 random, which is what a growing store looks like — with business-hours timestamps rather than uniform across midnight.

This matters because **every report in the EasyCommerce admin is date-range driven**. Before, a whole generated catalogue collapsed into one spike:

```
2026-07-09    27 orders      ← the entire store
```

## Verified on a live store

12 orders, `date_range_days=120`:

```
2026-04-15  1     2026-06-13  1
2026-05-09  1     2026-06-16  1
2026-05-15  1     2026-06-17  1
2026-05-23  1     2026-06-21  1
2026-05-24  1     2026-07-06  1
                  2026-07-19  1
                  2026-07-20  1

oldest 2026-04-15 21:53:54 · newest 2026-07-20 20:51:59 · 12 distinct days
```

12 orders, 12 distinct days, 96-day span inside the 120 requested, with the recency bias visible.

**Cleanup:** all test orders plus their `order_meta`, `order_items` and `transactions` rows were deleted, and I tracked down one orphan left by the crash before the fix. The store is back to exactly its prior state — 27 orders on 2026-07-09 — and the working checkout is clean.

`php -l` clean, `yarn build` compiles, and the parameter is wired through the REST schema and the admin UI.

## Follow-up worth considering

`transactions` and `refunds` also carry `created_at` and are generated against existing orders — they'll still be stamped today, so a 3-month-old order can have a transaction dated now. Same treatment would fix it; out of scope here.
