### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Release dates are taken from the release tags in this repository. The [`readme.t
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-07-20
+
 ### Added
 
 - Order statuses `failed` and `partially_refunded`, and the cart status `payment_initiated`, all of which EasyCommerce added to its column definitions after the last sync.
@@ -18,6 +20,8 @@ Release dates are taken from the release tags in this repository. The [`readme.t
 - **Breaking:** The minimum WordPress version is now 6.6, corrected from 5.0. The admin app depends on the `react-jsx-runtime` script handle that core registers in 6.6, and the `Requires Plugins` header needs 6.5, so the old floor was never accurate — the plugin could not run on it.
 - New brand mark: a shopping bag holding rows of generated data, replacing the sparkle. Applied to the WordPress.org icon and banners, the admin menu icon, the sidebar, and the logo lockup.
 - The live preview now shows up to 25 rows instead of 12, matching what the preview endpoint already returns.
+- Compatibility declared with WordPress 7.0.
+- JavaScript dependencies updated, including a move to yarn 4.17.
 
 ### Fixed
 
@@ -33,6 +37,11 @@ Release dates are taken from the release tags in this repository. The [`readme.t
 - Attributes created during variation generation use a type EasyCommerce recognises, so they render correctly in the attribute editor.
 - Shipping tiers with no upper bound are stored as unlimited rather than as a large sentinel amount.
 - The cart status distribution parameter now rejects unknown statuses instead of passing them through to the database.
+- Order generation no longer fails outright for customers whose address was saved at checkout. The stored address came back as an object where an array was expected, and because the resulting error was not an exception the whole batch stopped rather than skipping one item.
+- Generated orders are spread over time instead of all landing on the day they were generated, so the date-range reports in the EasyCommerce admin have something to show. A new date range setting controls the window.
+- Headings inside the plugin follow the active theme instead of staying dark, which left page titles unreadable in dark mode.
+- The generators no longer use FakerPHP's deprecated property access, which emitted a deprecation notice for every generated field.
+- The preview pane is bounded by the window rather than stretched by the settings column, and the preview table scrolls within its own card.
 
 ## [2.2.0] - 2026-06-11
 
@@ -208,7 +217,8 @@ No release tag exists for this version, so it has no comparison link.
 - React 18 interface with real-time feedback.
 - PSR-4 architecture with native EasyCommerce model integration.
 
-[Unreleased]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.0.4...v2.1.0
 [2.0.4]: https://github.com/mralaminahamed/easycommerce-fakerpress/compare/v2.0.3...v2.0.4

--- a/class-easycommerce-fakerpress.php
+++ b/class-easycommerce-fakerpress.php
@@ -50,7 +50,7 @@ use EasyCommerceFakerPress\MCP\MCP_Server;
  * - Multi-locale support for international data generation
  *
  * @since 1.0.0
- * @version 2.2.0
+ * @version 2.3.0
  */
 class EasyCommerce_FakerPress {
 

--- a/easycommerce-fakerpress.php
+++ b/easycommerce-fakerpress.php
@@ -11,7 +11,7 @@
  * Plugin Name:       EasyCommerce FakerPress
  * Plugin URI:        https://github.com/mralaminahamed/easycommerce-fakerpress
  * Description:       Create realistic test data for your EasyCommerce store in seconds! Generate products, customers, orders, coupons and more with our intuitive admin interface. Perfect for development, testing, and demos. Features smart defaults, real-time validation, and seamless WordPress integration.
- * Version:           2.2.0
+ * Version:           2.3.0
  * Requires at least: 6.6
  * Requires PHP:      7.4
  * Requires Plugins:  easycommerce
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'EASYCOMMERCE_FAKERPRESS_VERSION', '2.2.0' );
+define( 'EASYCOMMERCE_FAKERPRESS_VERSION', '2.3.0' );
 define( 'EASYCOMMERCE_FAKERPRESS_PLUGIN_FILE', __FILE__ );
 define( 'EASYCOMMERCE_FAKERPRESS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'EASYCOMMERCE_FAKERPRESS_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mralaminahamed/easycommerce-fakerpress",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "engines": {
     "node": ">=18.0.0",
     "yarn": ">=1.22.0"

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 6.6
 Tested up to: 7.0
 Requires PHP: 7.4
 Requires Plugins: easycommerce
-Stable tag: 2.2.0
+Stable tag: 2.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -149,6 +149,18 @@ In your browser's localStorage, not your database. Clearing it has no effect on 
 
 The four most recent releases are listed below. For the complete version history, see the [full changelog on GitHub](https://github.com/mralaminahamed/easycommerce-fakerpress/blob/trunk/CHANGELOG.md).
 
+= 2.3.0 - July 20, 2026 =
+* Order generation no longer fails for customers whose address was saved at checkout — a stored address came back in a shape the generator rejected, and the whole batch stopped instead of skipping one item
+* Generated orders are now spread over a configurable date range instead of all landing on today, so the EasyCommerce date-range reports have data to show
+* Generated orders carry the address, tax and shipping meta EasyCommerce reads, so they render complete in the admin
+* Aligned generated statuses, attributes, tax classes, coupon rules and shipping tiers with the current EasyCommerce database schema
+* A run where every item failed now reports why, instead of claiming success with zero items created
+* Headings follow the active theme, fixing unreadable page titles in dark mode
+* Live preview shows up to 25 rows and scrolls within its own card
+* New brand mark, refreshed WordPress.org icon and banners
+* Minimum WordPress version corrected to 6.6, and compatibility declared with WordPress 7.0
+* Removed a deprecation notice raised for every generated field
+
 = 2.2.0 - June 11, 2026 =
 * Complete admin UI redesign on a new design-token system — light/dark themes, 5 accent palettes, and comfortable/compact density, all scoped so WordPress chrome is never restyled
 * New dashboard with stat cards, sparklines and a recent-activity feed driven by real run history
@@ -170,13 +182,10 @@ The four most recent releases are listed below. For the complete version history
 * Build output renamed from index to app, with the asset path updated to match
 * Dependencies updated, including PHPStan 2.1.40
 
-= 2.0.3 - January 14, 2026 =
-* New Product Review generator with weighted ratings and verified-purchase support
-* WordPress comments integration for review storage
-* Order generator data structure corrected to match the EasyCommerce Order model
-* Controller pattern and API schema consistency improvements
-
 == Upgrade Notice ==
+
+= 2.3.0 =
+Fixes order generation failing for customers with a saved address, and spreads generated orders over a date range so the EasyCommerce reports show data. Generators realigned with the current EasyCommerce schema. Minimum WordPress is now 6.6.
 
 = 2.2.0 =
 Complete admin UI redesign with a new design-token system, dashboard, live preview, command palette, batch queue, and dark mode. No database migrations required. REST API, generator parameters, and custom hooks are unchanged.


### PR DESCRIPTION
Release prep for **2.3.0**. Merging this then tagging `v2.3.0` publishes to WordPress.org.

## Version choice

**Minor, not major.** The only entry marked breaking is the corrected minimum WordPress version — that raises a stated requirement rather than changing an API. Nothing in the REST contract, generator parameters, or hooks changed incompatibly, and code added this cycle already carries `@since 2.3.0`.

## Version sources synced

| Source | |
|---|---|
| `easycommerce-fakerpress.php` header | 2.3.0 |
| `EASYCOMMERCE_FAKERPRESS_VERSION` | 2.3.0 |
| `readme.txt` `Stable tag` | 2.3.0 |
| `package.json` | 2.3.0 |

The deploy workflow hard-fails if the tag doesn't match the header, so these had to move before tagging.

## What's in the release

Thirteen merges. The headline items:

- **Order generation was fataling outright** for customers with a saved address — the whole batch stopped rather than skipping one item
- **Orders now spread over a date range** instead of all landing on today, which is what made every EasyCommerce date-range report show a single spike
- **Generators realigned with the current EasyCommerce schema** — statuses, variation attributes, tax classes, coupon rules, shipping tiers, order meta
- **A run where everything failed used to report success** with "0 items created"; it now reports why
- **Dark-mode headings** were unreadable
- New brand mark, WP 7.0 compatibility, minimum WordPress corrected to 6.6

## Changelog handling

`readme.txt` carries 2.3.0 and drops 2.0.3 to hold the four-release cap per the repo convention; `CHANGELOG.md` keeps the full history and gains the 2.3.0 compare link. I added the entries missing from `[Unreleased]` — dark headings, faker deprecations, preview layout, order fixes, dependency updates — since several merges hadn't been recorded.

Verified: exactly 4 changelog blocks, Upgrade Notices at 241/225/219/149 chars (cap 300), `php -l` clean, `yarn build` compiles.

## Not opened as a draft

Unlike the rest of this session's PRs — this one is the release gate and is meant to be merged, then tagged.
