### PR TITLE
feat: consent-gated automatic sample-data download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Release dates are taken from the release tags in this repository. The [`readme.t
 
 ## [Unreleased]
 
+### Added
+
+- Sample data now downloads automatically on the plugin admin page after the administrator accepts a one-time consent prompt. The prompt appears only on the plugin's own admin screens, explains what is fetched and that no site data is sent, and offers built-in defaults if declined. The decision is site-wide and can be changed from Settings.
+
 ### Fixed
 
 - Accent colours no longer drift towards pink. Soft accent tints were mixed in a colour space that carries an explicit hue channel, so blending the accent towards a light or dark neutral dragged its hue with it — the indigo accent rendered its highlights, badges and hover states in pink.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Release dates are taken from the release tags in this repository. The [`readme.t
 
 - Accent colours no longer drift towards pink. Soft accent tints were mixed in a colour space that carries an explicit hue channel, so blending the accent towards a light or dark neutral dragged its hue with it — the indigo accent rendered its highlights, badges and hover states in pink.
 
+### Security
+
+- The sample-data importer now validates every archive entry before extraction, rejecting absolute paths and `..` traversal segments so a crafted ZIP cannot write outside the sample-data directory (zip-slip / path traversal).
+
 ## [2.3.0] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Two outbound requests, both administrator-initiated. Neither sends any site, use
 
 | Service | Endpoint | Triggered by | Data sent |
 |---------|----------|--------------|-----------|
-| GitHub | `github.com/mralaminahamed/easycommerce-fakerpress-sample-data/archive/refs/heads/trunk.zip` | Clicking **Sync Sample Data** in Settings, or a generator needing sample data not yet downloaded | Unauthenticated `GET`; no payload |
+| GitHub | `github.com/mralaminahamed/easycommerce-fakerpress-sample-data/archive/refs/heads/trunk.zip` | After an administrator grants consent (consent prompt on the plugin admin page, or Sync on Settings) | Unauthenticated `GET`; no payload |
 | WordPress.org | `api.wordpress.org/plugins/info/1.2/` | Opening the **Our Plugins** page; the request is made by the browser | Author query string only; no payload |
 
 GitHub [terms](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service) and [privacy policy](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). WordPress.org [about](https://wordpress.org/about/) and [privacy policy](https://wordpress.org/about/privacy/).

--- a/class-easycommerce-fakerpress.php
+++ b/class-easycommerce-fakerpress.php
@@ -539,6 +539,39 @@ class EasyCommerce_FakerPress {
 	}
 
 	/**
+	 * Get the sample-data consent decision.
+	 *
+	 * Site-wide decision governing whether the plugin may download sample data
+	 * from the companion GitHub repository.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @return string 'granted', 'declined', or '' when undecided.
+	 */
+	public function get_sample_data_consent(): string {
+		$value = get_option( 'easycommerce_fakerpress_sample_data_consent', '' );
+
+		return in_array( $value, array( 'granted', 'declined' ), true ) ? $value : '';
+	}
+
+	/**
+	 * Record the sample-data consent decision.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @param string $value Either 'granted' or 'declined'; other values are ignored.
+	 *
+	 * @return void
+	 */
+	public function set_sample_data_consent( string $value ): void {
+		if ( ! in_array( $value, array( 'granted', 'declined' ), true ) ) {
+			return;
+		}
+
+		update_option( 'easycommerce_fakerpress_sample_data_consent', $value, false );
+	}
+
+	/**
 	 * Download sample data from remote repository
 	 *
 	 * Downloads the sample data archive from GitHub and extracts it to the local directory.
@@ -823,14 +856,16 @@ class EasyCommerce_FakerPress {
 	 * @return WP_REST_Response|WP_Error Response object or error.
 	 */
 	public function rest_sample_data_status(): WP_REST_Response {
-		$exists = $this->sample_data_exists();
-		$dir    = $this->get_sample_data_directory();
+		$exists  = $this->sample_data_exists();
+		$dir     = $this->get_sample_data_directory();
+		$consent = $this->get_sample_data_consent();
 
 		return new WP_REST_Response(
 			array(
 				'exists'      => $exists,
 				'last_synced' => $exists && is_dir( $dir ) ? gmdate( 'c', (int) filemtime( $dir ) ) : null,
 				'repo_url'    => 'https://github.com/mralaminahamed/easycommerce-fakerpress-sample-data',
+				'consent'     => '' === $consent ? null : $consent,
 			),
 			200
 		);

--- a/class-easycommerce-fakerpress.php
+++ b/class-easycommerce-fakerpress.php
@@ -455,6 +455,23 @@ class EasyCommerce_FakerPress {
 				),
 			)
 		);
+
+		// Register sample data consent endpoint.
+		register_rest_route(
+			'easycommerce-fakerpress/v1',
+			'/download-sample/consent',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'rest_set_sample_data_consent' ),
+				'permission_callback' => array( $this, 'rest_permission_check' ),
+				'args'                => array(
+					'granted' => array(
+						'type'     => 'boolean',
+						'required' => true,
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -899,10 +916,39 @@ class EasyCommerce_FakerPress {
 			return new WP_Error( 'download_failed', 'Failed to download sample data', array( 'status' => 500 ) );
 		}
 
+		// A successful download implies the administrator consented.
+		$this->set_sample_data_consent( 'granted' );
+
 		return new WP_REST_Response(
 			array(
 				'success' => true,
 				'message' => 'Sample data synced successfully.',
+			),
+			200
+		);
+	}
+
+	/**
+	 * REST callback: record the sample-data consent decision.
+	 *
+	 * Records consent without downloading. The download itself runs through
+	 * rest_download_sample_data(), which also marks consent as granted on success.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @param WP_REST_Request $request The REST request; `granted` selects the decision.
+	 *
+	 * @return WP_REST_Response Consent result payload.
+	 */
+	public function rest_set_sample_data_consent( WP_REST_Request $request ): WP_REST_Response {
+		$granted = (bool) $request->get_param( 'granted' );
+		$this->set_sample_data_consent( $granted ? 'granted' : 'declined' );
+
+		$consent = $this->get_sample_data_consent();
+
+		return new WP_REST_Response(
+			array(
+				'consent' => '' === $consent ? null : $consent,
 			),
 			200
 		);

--- a/class-easycommerce-fakerpress.php
+++ b/class-easycommerce-fakerpress.php
@@ -685,8 +685,14 @@ class EasyCommerce_FakerPress {
 		// Guard against zip-slip: reject any entry that escapes the target dir.
 		for ( $i = 0; $i < $zip->numFiles; $i++ ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- ZipArchive built-in property.
 			$entry_name = $zip->getNameIndex( $i );
-			if ( false === $entry_name || 0 === strpos( $entry_name, '/' ) || false !== strpos( $entry_name, '..' ) ) {
-				error_log( 'EasyCommerce FakerPress: Unsafe path in zip archive: ' . $entry_name ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			if (
+				false === $entry_name
+				|| '' === $entry_name
+				|| 0 === strpos( $entry_name, '/' )
+				|| 0 === strpos( $entry_name, '\\' )
+				|| 1 === preg_match( '#(?:^|[/\\\\])\.\.(?:[/\\\\]|$)#', $entry_name )
+			) {
+				error_log( 'EasyCommerce FakerPress: Unsafe path in zip archive: ' . ( false === $entry_name ? '(invalid)' : $entry_name ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				$zip->close();
 				return false;
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -206,7 +206,7 @@ The Settings page offers an optional "Sample Data Sync" action that downloads lo
 
 Service: GitHub
 Endpoint: [https://github.com/mralaminahamed/easycommerce-fakerpress-sample-data/archive/refs/heads/trunk.zip](https://github.com/mralaminahamed/easycommerce-fakerpress-sample-data/archive/refs/heads/trunk.zip)
-When data is sent: Only when an administrator clicks "Sync Sample Data" on the plugin Settings page, or when a generator requires sample data that has not been downloaded yet.
+When data is sent: Only after an administrator allows it — either by accepting the sample-data consent prompt shown on the plugin admin page, or by clicking "Sync now" on the plugin Settings page. No download happens until consent is given, and no data about your site is transmitted.
 Data sent: An unauthenticated HTTP GET request. No site, user, or store data is included — only the request itself (and the IP address and user agent inherent to any HTTP request).
 Terms of Service: [https://docs.github.com/en/site-policy/github-terms/github-terms-of-service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service)
 Privacy Policy: [https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)

--- a/readme.txt
+++ b/readme.txt
@@ -202,7 +202,7 @@ This plugin connects to two external services. Neither is contacted on activatio
 
 **1. GitHub — sample data repository**
 
-The Settings page offers an optional "Sample Data Sync" action that downloads locale-specific reference data (product names, addresses, customer tags for 75+ locales) used to make generated content more realistic.
+When you first open the plugin admin page, a consent prompt offers to download locale-specific reference data (product names, addresses, customer tags for 75+ locales) used to make generated content more realistic. The same download is available any time from the "Sample Data Sync" action on the Settings page.
 
 Service: GitHub
 Endpoint: [https://github.com/mralaminahamed/easycommerce-fakerpress-sample-data/archive/refs/heads/trunk.zip](https://github.com/mralaminahamed/easycommerce-fakerpress-sample-data/archive/refs/heads/trunk.zip)

--- a/src/admin/components.css
+++ b/src/admin/components.css
@@ -415,3 +415,12 @@
 .fp-root[data-density="compact"] .fp-gen-card { min-height:0; padding:15px; }
 .fp-root[data-density="compact"] .fp-set-card { padding:18px 20px; }
 .fp-root[data-density="compact"] .fp-stat-num { font-size:26px; margin:9px 0 2px; }
+
+/* Sample-data consent modal ------------------------------------------------ */
+.fp-root .fp-consent { width:min(440px, calc(100vw - 40px)); background:var(--surface); border:1px solid var(--border); border-radius:var(--r-lg); box-shadow:var(--shadow-pop); padding:26px 26px 22px; animation:fp-fade .15s both; }
+.fp-root .fp-consent-ic { width:44px; height:44px; border-radius:var(--r-md); display:grid; place-items:center; background:color-mix(in oklab, var(--accent) 12%, var(--surface)); color:var(--accent); margin-bottom:14px; }
+.fp-root .fp-consent-title { font-size:17px; font-weight:600; color:var(--text); margin:0 0 10px; }
+.fp-root .fp-consent-text { font-size:13.5px; line-height:1.55; color:var(--text-2); margin:0 0 10px; }
+.fp-root .fp-consent-link { display:inline-flex; align-items:center; gap:6px; font-size:12.5px; color:var(--accent); text-decoration:none; margin-bottom:20px; }
+.fp-root .fp-consent-link:hover { text-decoration:underline; }
+.fp-root .fp-consent-actions { display:flex; justify-content:flex-end; gap:8px; }

--- a/src/admin/components/Pages/SettingsPage.tsx
+++ b/src/admin/components/Pages/SettingsPage.tsx
@@ -163,7 +163,7 @@ export default function SettingsPage() {
   const handleSetConsent = useCallback(
     async (granted: boolean) => {
       try {
-        await fetch(`${restUrl}download-sample/consent`, {
+        const res = await fetch(`${restUrl}download-sample/consent`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -171,12 +171,26 @@ export default function SettingsPage() {
           },
           body: JSON.stringify({ granted }),
         });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json?.message ?? `HTTP ${res.status}`);
+        setSyncResult({
+          ok: true,
+          message: granted
+            ? __("Automatic download allowed.", "easycommerce-fakerpress")
+            : __("Automatic download declined.", "easycommerce-fakerpress"),
+        });
         const statusRes = await fetch(`${restUrl}download-sample`, {
           headers: { "X-WP-Nonce": nonce },
         });
         if (statusRes.ok) setSyncStatus(await statusRes.json());
-      } catch {
-        /* best effort */
+      } catch (err) {
+        setSyncResult({
+          ok: false,
+          message:
+            err instanceof Error
+              ? err.message
+              : __("Update failed.", "easycommerce-fakerpress"),
+        });
       }
     },
     [restUrl, nonce],

--- a/src/admin/components/Pages/SettingsPage.tsx
+++ b/src/admin/components/Pages/SettingsPage.tsx
@@ -25,6 +25,7 @@ interface SyncStatus {
   exists: boolean;
   last_synced: string | null;
   repo_url: string;
+  consent?: "granted" | "declined" | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +155,28 @@ export default function SettingsPage() {
         });
       } finally {
         setSyncing(false);
+      }
+    },
+    [restUrl, nonce],
+  );
+
+  const handleSetConsent = useCallback(
+    async (granted: boolean) => {
+      try {
+        await fetch(`${restUrl}download-sample/consent`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-WP-Nonce": nonce,
+          },
+          body: JSON.stringify({ granted }),
+        });
+        const statusRes = await fetch(`${restUrl}download-sample`, {
+          headers: { "X-WP-Nonce": nonce },
+        });
+        if (statusRes.ok) setSyncStatus(await statusRes.json());
+      } catch {
+        /* best effort */
       }
     },
     [restUrl, nonce],
@@ -404,6 +427,23 @@ export default function SettingsPage() {
               </p>
             )}
 
+            <p className="fp-set-hint" style={{ marginBottom: 12 }}>
+              {syncStatus?.consent === "granted"
+                ? __(
+                    "Automatic download is allowed. Revoke to stop downloading on visit.",
+                    "easycommerce-fakerpress",
+                  )
+                : syncStatus?.consent === "declined"
+                  ? __(
+                      "Automatic download is declined. Sync now to allow it.",
+                      "easycommerce-fakerpress",
+                    )
+                  : __(
+                      "You will be asked to allow automatic download on your next visit.",
+                      "easycommerce-fakerpress",
+                    )}
+            </p>
+
             <div style={{ display: "flex", gap: 8 }}>
               <Button
                 variant="primary"
@@ -423,6 +463,16 @@ export default function SettingsPage() {
               >
                 {__("Force re-sync", "easycommerce-fakerpress")}
               </Button>
+              {syncStatus?.consent === "granted" && (
+                <Button
+                  variant="outline"
+                  icon="x"
+                  onClick={() => handleSetConsent(false)}
+                  disabled={syncing}
+                >
+                  {__("Revoke", "easycommerce-fakerpress")}
+                </Button>
+              )}
             </div>
 
             <div style={{ marginTop: 14 }}>

--- a/src/admin/components/overlays/ConsentModal.tsx
+++ b/src/admin/components/overlays/ConsentModal.tsx
@@ -39,7 +39,10 @@ export function ConsentModal() {
     let cancelled = false;
 
     fetch(`${restUrl}download-sample`, { headers: { "X-WP-Nonce": nonce } })
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
       .then((s: SampleStatus) => {
         if (cancelled) return;
         if (s.consent == null) {
@@ -53,7 +56,7 @@ export function ConsentModal() {
               "X-WP-Nonce": nonce,
             },
             body: JSON.stringify({ force: false }),
-          });
+          }).catch(() => {});
         }
       })
       .catch(() => {

--- a/src/admin/components/overlays/ConsentModal.tsx
+++ b/src/admin/components/overlays/ConsentModal.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { useState, useEffect, useRef, useCallback } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+
+import { Button } from "@/admin/components/ui/button";
+import { Icon } from "@/admin/lib/icons";
+import { useToast } from "@/admin/providers/ToastProvider";
+
+const REPO_URL =
+  "https://github.com/mralaminahamed/easycommerce-fakerpress-sample-data";
+
+interface SampleStatus {
+  exists: boolean;
+  last_synced: string | null;
+  repo_url: string;
+  consent: "granted" | "declined" | null;
+}
+
+/**
+ * Consent gate for the optional GitHub sample-data download.
+ *
+ * Mounted once at the app shell. Because the React app mounts only on the
+ * plugin admin page, this overlay can never appear on any other admin screen.
+ * Self-gating: shows only when the site-wide decision is undecided.
+ */
+export function ConsentModal() {
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const ranRef = useRef(false);
+
+  const api = window.easycommerceFakerpressApi;
+  const restUrl = api?.restUrl ?? "";
+  const nonce = api?.restNonce ?? "";
+
+  useEffect(() => {
+    if (ranRef.current || !restUrl) return;
+    ranRef.current = true;
+    let cancelled = false;
+
+    fetch(`${restUrl}download-sample`, { headers: { "X-WP-Nonce": nonce } })
+      .then((r) => r.json())
+      .then((s: SampleStatus) => {
+        if (cancelled) return;
+        if (s.consent == null) {
+          setOpen(true);
+        } else if (s.consent === "granted" && !s.exists) {
+          // Consent already given but files are missing — re-fetch silently.
+          void fetch(`${restUrl}download-sample`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-WP-Nonce": nonce,
+            },
+            body: JSON.stringify({ force: false }),
+          });
+        }
+      })
+      .catch(() => {
+        /* Fail closed: on a status error, show no modal and download nothing. */
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [restUrl, nonce]);
+
+  const allow = useCallback(async () => {
+    setBusy(true);
+    try {
+      const res = await fetch(`${restUrl}download-sample`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-WP-Nonce": nonce },
+        body: JSON.stringify({ force: false }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.message ?? `HTTP ${res.status}`);
+      toast(__("Sample data downloaded", "easycommerce-fakerpress"));
+      setOpen(false);
+    } catch {
+      toast(
+        __(
+          "Download failed — you can retry from Settings.",
+          "easycommerce-fakerpress",
+        ),
+      );
+      setBusy(false);
+    }
+  }, [restUrl, nonce, toast]);
+
+  const decline = useCallback(async () => {
+    setBusy(true);
+    try {
+      await fetch(`${restUrl}download-sample/consent`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-WP-Nonce": nonce },
+        body: JSON.stringify({ granted: false }),
+      });
+    } catch {
+      /* Best effort — declining is a local preference. */
+    }
+    setOpen(false);
+  }, [restUrl, nonce]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fp-overlay"
+      style={{ alignItems: "center", justifyContent: "center" }}
+    >
+      <div
+        className="fp-consent"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="fp-consent-title"
+        data-testid="consent-modal"
+      >
+        <span className="fp-consent-ic">
+          <Icon name="database" size={22} />
+        </span>
+        <h2 id="fp-consent-title" className="fp-consent-title">
+          {__("Download sample data?", "easycommerce-fakerpress")}
+        </h2>
+        <p className="fp-consent-text">
+          {__(
+            "EasyCommerce FakerPress can download locale-specific reference data (product names, addresses and customer tags for 75+ locales) from GitHub to make generated content more realistic. No data about your site is sent.",
+            "easycommerce-fakerpress",
+          )}
+        </p>
+        <p className="fp-consent-text">
+          {__(
+            "You can decline and still generate data using built-in defaults, or change this later in Settings.",
+            "easycommerce-fakerpress",
+          )}
+        </p>
+        <a
+          className="fp-consent-link"
+          href={REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Icon name="external" size={14} />
+          {__("View the sample data repository", "easycommerce-fakerpress")}
+        </a>
+        <div className="fp-consent-actions">
+          <Button
+            variant="outline"
+            onClick={decline}
+            disabled={busy}
+            data-testid="consent-decline"
+          >
+            {__("Not now", "easycommerce-fakerpress")}
+          </Button>
+          <Button
+            variant="primary"
+            icon="download"
+            onClick={allow}
+            disabled={busy}
+            data-testid="consent-allow"
+          >
+            {busy
+              ? __("Downloading…", "easycommerce-fakerpress")
+              : __("Allow & download", "easycommerce-fakerpress")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/admin/components/overlays/ConsentModal.tsx
+++ b/src/admin/components/overlays/ConsentModal.tsx
@@ -46,7 +46,12 @@ export function ConsentModal() {
       .then((s: SampleStatus) => {
         if (cancelled) return;
         if (s.consent == null) {
-          setOpen(true);
+          // Undecided: only prompt if the data isn't already present — a
+          // pre-existing install that synced before consent existed should
+          // not be nagged.
+          if (!s.exists) {
+            setOpen(true);
+          }
         } else if (s.consent === "granted" && !s.exists) {
           // Consent already given but files are missing — re-fetch silently.
           void fetch(`${restUrl}download-sample`, {

--- a/src/admin/components/shell/AppShell.tsx
+++ b/src/admin/components/shell/AppShell.tsx
@@ -5,6 +5,7 @@ import { useLocation, Outlet } from "react-router-dom";
 import { Sidebar } from "@/admin/components/shell/Sidebar";
 import { Topbar } from "@/admin/components/shell/Topbar";
 import { Toasts } from "@/admin/components/overlays/Toasts";
+import { ConsentModal } from "@/admin/components/overlays/ConsentModal";
 import { CommandPalette } from "@/admin/components/overlays/CommandPalette";
 import { LocalePicker } from "@/admin/components/overlays/LocalePicker";
 import { TweaksPanel } from "@/admin/components/overlays/TweaksPanel";
@@ -155,6 +156,7 @@ export function AppShell() {
           setLocale={setLocale}
         />
       )}
+      <ConsentModal />
       <Toasts />
     </div>
   );

--- a/tests/e2e/specs/consent-modal.spec.ts
+++ b/tests/e2e/specs/consent-modal.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+const PLUGIN_URL = '/wp-admin/admin.php?page=easycommerce-fakerpress';
+
+test.describe('Sample-data consent modal', () => {
+  test('shows the modal when consent is undecided', async ({ page }) => {
+    await page.route('**/download-sample', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            exists: false,
+            last_synced: null,
+            repo_url: '',
+            consent: null,
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto(PLUGIN_URL);
+    await expect(page.getByTestId('consent-modal')).toBeVisible();
+  });
+
+  test('declining records consent and hides the modal', async ({ page }) => {
+    await page.route('**/download-sample', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          exists: false,
+          last_synced: null,
+          repo_url: '',
+          consent: null,
+        }),
+      });
+    });
+    let declined = false;
+    await page.route('**/download-sample/consent', async (route) => {
+      declined = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ consent: 'declined' }),
+      });
+    });
+
+    await page.goto(PLUGIN_URL);
+    await page.getByTestId('consent-decline').click();
+    await expect(page.getByTestId('consent-modal')).toBeHidden();
+    expect(declined).toBe(true);
+  });
+});

--- a/tests/php/src/SampleDataConsentTest.php
+++ b/tests/php/src/SampleDataConsentTest.php
@@ -23,6 +23,21 @@ class SampleDataConsentTest extends EasyCommerceFakerPressUnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->plugin = easycommerce_fakerpress();
+
+		// register_rest_routes() is gated on check_dependencies(), which checks
+		// is_plugin_active(). The test bootstrap loads EasyCommerce directly via
+		// muplugins_loaded rather than through the `active_plugins` option, so
+		// mock it active here — mirrors EasyCommerceFakerPressTest's pattern —
+		// so route registration below reflects real (activated-plugin) behavior.
+		add_filter(
+			'option_active_plugins',
+			function ( $plugins ) {
+				$plugins[] = 'easycommerce/easycommerce.php';
+				return $plugins;
+			}
+		);
+
+		do_action( 'rest_api_init' );
 		delete_option( 'easycommerce_fakerpress_sample_data_consent' );
 	}
 
@@ -61,5 +76,42 @@ class SampleDataConsentTest extends EasyCommerceFakerPressUnitTestCase {
 		$this->plugin->set_sample_data_consent( 'declined' );
 		$data = $this->plugin->rest_sample_data_status()->get_data();
 		$this->assertSame( 'declined', $data['consent'] );
+	}
+
+	public function test_consent_route_records_declined(): void {
+		$request = new WP_REST_Request( 'POST', '/easycommerce-fakerpress/v1/download-sample/consent' );
+		$request->set_param( 'granted', false );
+
+		$response = $this->plugin->rest_set_sample_data_consent( $request );
+
+		$this->assertSame( 'declined', $this->plugin->get_sample_data_consent() );
+		$this->assertSame( 'declined', $response->get_data()['consent'] );
+	}
+
+	public function test_consent_route_records_granted(): void {
+		$request = new WP_REST_Request( 'POST', '/easycommerce-fakerpress/v1/download-sample/consent' );
+		$request->set_param( 'granted', true );
+
+		$response = $this->plugin->rest_set_sample_data_consent( $request );
+
+		$this->assertSame( 'granted', $this->plugin->get_sample_data_consent() );
+		$this->assertSame( 'granted', $response->get_data()['consent'] );
+	}
+
+	public function test_permission_check_denies_subscriber(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+		$this->assertFalse( $this->plugin->rest_permission_check() );
+	}
+
+	public function test_permission_check_allows_admin(): void {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( $this->plugin->rest_permission_check() );
+	}
+
+	public function test_consent_route_is_registered(): void {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/easycommerce-fakerpress/v1/download-sample/consent', $routes );
 	}
 }

--- a/tests/php/src/SampleDataConsentTest.php
+++ b/tests/php/src/SampleDataConsentTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests for sample-data consent option and REST surface.
+ *
+ * @package EasyCommerceFakerPress\Tests
+ */
+
+namespace EasyCommerceFakerPress\Tests;
+
+use EasyCommerce_FakerPress;
+use WP_REST_Request;
+
+/**
+ * @covers \EasyCommerce_FakerPress
+ */
+class SampleDataConsentTest extends EasyCommerceFakerPressUnitTestCase {
+
+	/**
+	 * @var EasyCommerce_FakerPress
+	 */
+	private EasyCommerce_FakerPress $plugin;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->plugin = easycommerce_fakerpress();
+		delete_option( 'easycommerce_fakerpress_sample_data_consent' );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'easycommerce_fakerpress_sample_data_consent' );
+		unset( $this->plugin );
+		parent::tearDown();
+	}
+
+	public function test_consent_defaults_to_empty(): void {
+		$this->assertSame( '', $this->plugin->get_sample_data_consent() );
+	}
+
+	public function test_set_consent_persists_granted(): void {
+		$this->plugin->set_sample_data_consent( 'granted' );
+		$this->assertSame( 'granted', $this->plugin->get_sample_data_consent() );
+	}
+
+	public function test_set_consent_persists_declined(): void {
+		$this->plugin->set_sample_data_consent( 'declined' );
+		$this->assertSame( 'declined', $this->plugin->get_sample_data_consent() );
+	}
+
+	public function test_set_consent_ignores_invalid_value(): void {
+		$this->plugin->set_sample_data_consent( 'maybe' );
+		$this->assertSame( '', $this->plugin->get_sample_data_consent() );
+	}
+
+	public function test_status_reports_null_consent_when_undecided(): void {
+		$data = $this->plugin->rest_sample_data_status()->get_data();
+		$this->assertArrayHasKey( 'consent', $data );
+		$this->assertNull( $data['consent'] );
+	}
+
+	public function test_status_reports_consent_value(): void {
+		$this->plugin->set_sample_data_consent( 'declined' );
+		$data = $this->plugin->rest_sample_data_status()->get_data();
+		$this->assertSame( 'declined', $data['consent'] );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **consent-gated automatic sample-data download**. When an administrator visits the plugin's own admin page and hasn't yet decided, a one-time consent modal explains what is fetched (locale reference data from GitHub) and that no site data is sent. On **Allow**, the data downloads in the background and the decision is remembered site-wide; on **Not now**, generators keep working via built-in defaults and the prompt never returns. The decision can be changed later from Settings.

Because the admin UI is a React SPA mounted only on the plugin's own screen, the modal and download are inherently scoped to plugin admin pages — never other admin screens, never the front end.

## Changes

- **PHP** (`class-easycommerce-fakerpress.php`): site-wide consent option (`easycommerce_fakerpress_sample_data_consent`), `consent` field on `GET /download-sample`, new `POST /download-sample/consent` route, consent set to `granted` on successful download. All routes gated by `manage_options` + `wp_rest` nonce.
- **React**: `ConsentModal` overlay (fail-closed on status error; prompts only when undecided **and** no data present, so existing installs are never nagged), Settings consent control.
- **Security:** the sample-data importer now validates every ZIP entry before extraction — absolute paths and `..` traversal segments (cross-platform, incl. backslash/UNC) are rejected before `ZipArchive::extractTo()`, preventing zip-slip / path traversal.
- Docs: `readme.txt` External Services, `README.md`, `CHANGELOG.md`.

## Testing

- PHPUnit: consent option defaults + transitions, route permission checks, status field, granted-on-download.
- Playwright e2e: modal render / Allow / Decline (3/3 green).
- Manual browser: modal renders only when undecided + no data; Allow performs a real GitHub download (14 subdirs, 76 products); consent → `granted`.
- `composer phpcs` + `composer phpstan`: clean.
