### PR TITLE
Tell Our Plugins what this site already has

### DIFF
--- a/class-easycommerce-fakerpress.php
+++ b/class-easycommerce-fakerpress.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use EasyCommerceFakerPress\Controllers\Plugins;
 use EasyCommerceFakerPress\Controllers\Product;
 use EasyCommerceFakerPress\Controllers\Customer;
 use EasyCommerceFakerPress\Controllers\Order;
@@ -431,6 +432,13 @@ class EasyCommerce_FakerPress {
 		foreach ( $controllers as $controller ) {
 			$controller->register_routes();
 		}
+
+		/*
+		 * Not in the array above: that list is generators, and the Our Plugins
+		 * endpoint fabricates nothing. Registered separately for the same reason
+		 * `/download-sample` below is.
+		 */
+		( new Plugins() )->register_routes();
 
 		// Register download sample data endpoint.
 		register_rest_route(

--- a/includes/Controllers/Plugins.php
+++ b/includes/Controllers/Plugins.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * REST endpoint for the Our Plugins screen.
+ *
+ * @package EasyCommerceFakerPress
+ */
+
+declare( strict_types=1 );
+
+namespace EasyCommerceFakerPress\Controllers;
+
+use WP_Error;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Lists the author's other plugins with their state on this install.
+ *
+ * Not a generator, so it does not extend the Controller abstract the rest of
+ * this directory shares — that base exists to describe a thing this plugin can
+ * fabricate rows of, and a list of somebody's published work is not one. It
+ * registers its own route the same way `/download-sample` does.
+ *
+ * The screen used to call api.wordpress.org from the browser on every paint.
+ * That works, but it cannot know what the site already has, it re-fetches a
+ * list that changes about as often as a release, and a directory outage leaves
+ * it spinning with nothing to say.
+ *
+ * Nothing here installs or activates anything itself. The buttons point at
+ * wp-admin's own `update.php` and `plugins.php`, which already carry the
+ * capability checks, the nonces, the filesystem-credentials prompt and the
+ * rollback when a plugin fatals on activation.
+ */
+class Plugins {
+
+	private const REST_NAMESPACE = 'easycommerce-fakerpress/v1';
+
+	/**
+	 * The WordPress.org username whose plugins are listed.
+	 */
+	private const AUTHOR = 'mralaminahamed';
+
+	/**
+	 * This plugin's own slug, left off its own screen.
+	 */
+	private const SELF_SLUG = 'easycommerce-fakerpress';
+
+	private const CACHE_KEY = 'ecfp_our_plugins';
+
+	/**
+	 * How long the directory's answer is kept.
+	 *
+	 * The directory is a third-party HTTP request, and a screen that makes one
+	 * on every load hangs for as long as WordPress.org is having a bad day.
+	 * Twelve hours is far longer than the data changes and far shorter than a
+	 * release cycle.
+	 */
+	private const CACHE_TTL = 12 * HOUR_IN_SECONDS;
+
+	/**
+	 * Registers the route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/plugins',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_plugins' ),
+					'permission_callback' => array( $this, 'permission_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Who may read the list.
+	 *
+	 * The same gate as the rest of this plugin's REST surface. Reading which
+	 * plugins an author publishes is not privileged; the links the screen
+	 * renders are, and each is checked separately against the capability
+	 * WordPress uses for it.
+	 *
+	 * @return bool
+	 */
+	public function permission_check(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * The author's plugins, as the directory reports them.
+	 *
+	 * @return array{plugins: array<int, array<string, mixed>>, error: string}
+	 */
+	private function from_directory(): array {
+		$cached = get_transient( self::CACHE_KEY );
+
+		if ( is_array( $cached ) ) {
+			return array(
+				'plugins' => $cached,
+				'error'   => '',
+			);
+		}
+
+		if ( ! function_exists( 'plugins_api' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		}
+
+		/**
+		 * Filters the WordPress.org author whose plugins this screen lists.
+		 *
+		 * @param string $author The directory username.
+		 */
+		$author = (string) apply_filters( 'easycommerce_fakerpress_our_plugins_author', self::AUTHOR );
+
+		$response = plugins_api(
+			'query_plugins',
+			array(
+				'author'   => $author,
+				'per_page' => 24,
+				'fields'   => array(
+					'short_description' => true,
+					'icons'             => true,
+					'active_installs'   => true,
+					'ratings'           => false,
+					'sections'          => false,
+					'contributors'      => false,
+					'tags'              => false,
+					'compatibility'     => false,
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) || empty( $response->plugins ) ) {
+			/*
+			 * Cached briefly even on failure, or a directory that is down means
+			 * every load of this screen waits out the same timeout again.
+			 */
+			set_transient( self::CACHE_KEY, array(), 5 * MINUTE_IN_SECONDS );
+
+			return array(
+				'plugins' => array(),
+				'error'   => $response instanceof WP_Error
+					? $response->get_error_message()
+					: __( 'The plugin directory returned nothing.', 'easycommerce-fakerpress' ),
+			);
+		}
+
+		$plugins = array();
+
+		foreach ( $response->plugins as $plugin ) {
+			$plugin = (array) $plugin;
+			$slug   = (string) ( $plugin['slug'] ?? '' );
+
+			/**
+			 * Filters the slugs left off this screen.
+			 *
+			 * Only this plugin by default — listing the screen you are already
+			 * looking at.
+			 *
+			 * @param array $skip Plugin slugs.
+			 */
+			$skip = (array) apply_filters( 'easycommerce_fakerpress_our_plugins_skip', array( self::SELF_SLUG ) );
+
+			if ( '' === $slug || in_array( $slug, $skip, true ) ) {
+				continue;
+			}
+
+			$icons = (array) ( $plugin['icons'] ?? array() );
+
+			$plugins[] = array(
+				'slug'            => $slug,
+				'name'            => wp_strip_all_tags( (string) ( $plugin['name'] ?? $slug ) ),
+				'description'     => wp_strip_all_tags( (string) ( $plugin['short_description'] ?? '' ) ),
+				'version'         => (string) ( $plugin['version'] ?? '' ),
+				'active_installs' => (int) ( $plugin['active_installs'] ?? 0 ),
+
+				/*
+				 * The directory scores out of 100, not out of five. Converted
+				 * here so no caller has to know that, and `num_ratings` travels
+				 * with it — four stars from three people and four stars from
+				 * four hundred are not the same claim, and a rating shown
+				 * without its count implies the second.
+				 */
+				'rating'          => (float) ( $plugin['rating'] ?? 0 ) / 20,
+				'num_ratings'     => (int) ( $plugin['num_ratings'] ?? 0 ),
+
+				/*
+				 * `2x` where the directory has one: these render small on a
+				 * frequently retina screen, and the 1x asset is visibly soft.
+				 */
+				'icon'            => (string) ( $icons['2x'] ?? $icons['1x'] ?? $icons['svg'] ?? '' ),
+				'url'             => 'https://wordpress.org/plugins/' . $slug . '/',
+			);
+		}
+
+		set_transient( self::CACHE_KEY, $plugins, self::CACHE_TTL );
+
+		return array(
+			'plugins' => $plugins,
+			'error'   => '',
+		);
+	}
+
+	/**
+	 * The installed plugin file for a slug, or ''.
+	 *
+	 * @param string $slug Plugin directory slug.
+	 *
+	 * @return string
+	 */
+	private function plugin_file( string $slug ): string {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		foreach ( array_keys( get_plugins() ) as $file ) {
+			if ( dirname( $file ) === $slug ) {
+				return $file;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * The directory's list, marked with what this site already has.
+	 *
+	 * Install state is worked out on every request rather than cached with the
+	 * listing. The directory's answer changes on their schedule and the site's
+	 * contents change on the administrator's; caching them together would leave
+	 * a plugin reading "not installed" for hours after somebody installed it.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_plugins(): WP_REST_Response {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$directory = $this->from_directory();
+		$entries   = array();
+
+		foreach ( $directory['plugins'] as $plugin ) {
+			$file      = $this->plugin_file( $plugin['slug'] );
+			$is_active = '' !== $file && is_plugin_active( $file );
+
+			/*
+			 * Three states, not two. "Installed but switched off" is the one
+			 * worth distinguishing: the site already has the plugin and needs a
+			 * click rather than a download, and telling somebody to install what
+			 * they already have is how a screen loses their trust.
+			 */
+			$plugin['state'] = $is_active ? 'active' : ( '' !== $file ? 'inactive' : 'missing' );
+
+			/*
+			 * Core's own URLs, with core's own nonces. Empty for anybody without
+			 * the capability, so the screen renders the plugin without a button
+			 * rather than a button that refuses.
+			 */
+			if ( 'missing' === $plugin['state'] ) {
+				$plugin['action_url'] = current_user_can( 'install_plugins' )
+					? wp_nonce_url(
+						self_admin_url( 'update.php?action=install-plugin&plugin=' . rawurlencode( $plugin['slug'] ) ),
+						'install-plugin_' . $plugin['slug']
+					)
+					: '';
+			} elseif ( 'inactive' === $plugin['state'] ) {
+				$plugin['action_url'] = current_user_can( 'activate_plugins' )
+					? wp_nonce_url(
+						self_admin_url( 'plugins.php?action=activate&plugin=' . rawurlencode( $file ) ),
+						'activate-plugin_' . $file
+					)
+					: '';
+			} else {
+				$plugin['action_url'] = '';
+			}
+
+			$entries[] = $plugin;
+		}
+
+		return new WP_REST_Response(
+			array(
+				'plugins' => $entries,
+				'error'   => $directory['error'],
+			),
+			200
+		);
+	}
+}

--- a/src/admin/components/Pages/PluginsPage.tsx
+++ b/src/admin/components/Pages/PluginsPage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import apiFetch from "@wordpress/api-fetch";
 import { useEffect, useState } from "@wordpress/element";
 import { decodeEntities } from "@wordpress/html-entities";
 import { __, sprintf } from "@wordpress/i18n";
@@ -9,11 +10,16 @@ interface WPPlugin {
   name: string;
   slug: string;
   version: string;
-  short_description: string;
-  icons?: { "1x"?: string; "2x"?: string; svg?: string };
+  description: string;
+  icon: string;
+  /** Out of five; the server converts the directory's out-of-100 score. */
   rating: number;
   num_ratings: number;
   active_installs: number;
+  state: "active" | "inactive" | "missing";
+  /** Core's own install/activate URL, or "" when the user may not do it. */
+  action_url: string;
+  url: string;
 }
 
 export default function PluginsPage() {
@@ -21,28 +27,46 @@ export default function PluginsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  /*
+   * Asked of this plugin rather than of api.wordpress.org directly.
+   *
+   * The browser cannot know what the site already has installed, and calling
+   * the directory on every paint re-fetches a list that changes about as often
+   * as a release. The server caches it for twelve hours and answers with the
+   * state of each plugin here.
+   */
   useEffect(() => {
-    fetch(
-      "https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[author]=mralaminahamed&request[per_page]=20",
-    )
-      .then((r) => r.json())
-      .then((data: { plugins?: WPPlugin[] }) => {
-        setPlugins(
-          (data.plugins ?? []).filter(
-            (p) => p.slug !== "easycommerce-fakerpress",
-          ),
-        );
-        setLoading(false);
+    let cancelled = false;
+
+    apiFetch<{ plugins?: WPPlugin[]; error?: string }>({
+      path: "/easycommerce-fakerpress/v1/plugins",
+    })
+      .then((data) => {
+        if (cancelled) return;
+        setPlugins(data.plugins ?? []);
+        if (data.error) {
+          setError(
+            __(
+              "The plugin directory could not be reached, so this list may be incomplete.",
+              "easycommerce-fakerpress",
+            ),
+          );
+        }
       })
       .catch(() => {
-        setError(
-          __(
-            "Could not load plugins. Check your internet connection.",
-            "easycommerce-fakerpress",
-          ),
-        );
-        setLoading(false);
+        if (!cancelled) {
+          setError(
+            __("Could not load plugins.", "easycommerce-fakerpress"),
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   return (
@@ -125,9 +149,13 @@ function Rating({ r, rc }: { r: number; rc: number }) {
 }
 
 function PluginCard({ plugin }: { plugin: WPPlugin }) {
-  const icon =
-    plugin.icons?.svg ?? plugin.icons?.["2x"] ?? plugin.icons?.["1x"];
-  const stars = Math.round(plugin.rating / 20);
+  const icon = plugin.icon;
+  /*
+   * Already out of five. The directory scores out of a hundred and the server
+   * divides on the way out, so dividing again here flattens every rating to
+   * nought stars.
+   */
+  const stars = Math.round(plugin.rating);
 
   return (
     <div className="fp-card fp-plugin-card">
@@ -151,7 +179,7 @@ function PluginCard({ plugin }: { plugin: WPPlugin }) {
       </div>
 
       <p className="fp-plugin-desc">
-        {decodeEntities(plugin.short_description)}
+        {decodeEntities(plugin.description)}
       </p>
 
       <div className="fp-plugin-foot">
@@ -165,17 +193,51 @@ function PluginCard({ plugin }: { plugin: WPPlugin }) {
         </span>
       </div>
 
-      <a
-        href={`https://wordpress.org/plugins/${plugin.slug}/`}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="full-w"
-        style={{ display: "block" }}
-      >
-        <Button variant="outline" size="sm" icon="external" className="full-w" type="button">
-          {__("View on WordPress.org", "easycommerce-fakerpress")}
+      {/*
+        Three states, not two. "Installed but switched off" is the one worth
+        telling apart: the site has the plugin and needs a click, not a
+        download.
+
+        The links are core's own update.php and plugins.php with core's own
+        nonces, built server-side — and empty for anybody without the
+        capability, so what renders is the plugin without a button rather than
+        a button that refuses.
+      */}
+      {plugin.state === "active" && (
+        <Button variant="outline" size="sm" className="full-w" type="button" disabled>
+          {__("Active", "easycommerce-fakerpress")}
         </Button>
-      </a>
+      )}
+
+      {plugin.state === "inactive" && plugin.action_url && (
+        <a href={plugin.action_url} className="full-w" style={{ display: "block" }}>
+          <Button variant="primary" size="sm" className="full-w" type="button">
+            {__("Activate", "easycommerce-fakerpress")}
+          </Button>
+        </a>
+      )}
+
+      {plugin.state === "missing" && plugin.action_url && (
+        <a href={plugin.action_url} className="full-w" style={{ display: "block" }}>
+          <Button variant="primary" size="sm" className="full-w" type="button">
+            {__("Install now", "easycommerce-fakerpress")}
+          </Button>
+        </a>
+      )}
+
+      {(plugin.state === "active" || !plugin.action_url) && (
+        <a
+          href={plugin.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="full-w"
+          style={{ display: "block" }}
+        >
+          <Button variant="outline" size="sm" icon="external" className="full-w" type="button">
+            {__("View on WordPress.org", "easycommerce-fakerpress")}
+          </Button>
+        </a>
+      )}
     </div>
   );
 }

--- a/tests/php/src/Controllers/PluginsRESTControllerTest.php
+++ b/tests/php/src/Controllers/PluginsRESTControllerTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace EasyCommerceFakerPress\Tests\Controllers;
+
+use EasyCommerceFakerPress\Controllers\Plugins;
+use EasyCommerceFakerPress\Tests\EasyCommerceFakerPressUnitTestCase;
+use WP_Error;
+
+/**
+ * Test class for the Our Plugins REST controller.
+ *
+ * The list comes from the WordPress.org directory, so `plugins_api` is filtered
+ * rather than called: what matters is that the answer is cached, that install
+ * state is read from this site rather than from the cache, that the action
+ * links carry core's own nonces, and that an unreachable directory degrades to
+ * a message instead of an error.
+ *
+ * @covers \EasyCommerceFakerPress\Controllers\Plugins
+ */
+class PluginsRESTControllerTest extends EasyCommerceFakerPressUnitTestCase {
+
+	/**
+	 * @var Plugins
+	 */
+	private $controller;
+
+	private const CACHE_KEY = 'ecfp_our_plugins';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->controller = new Plugins();
+
+		delete_transient( self::CACHE_KEY );
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'plugins_api' );
+		delete_transient( self::CACHE_KEY );
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Answer the directory with a fixture rather than a network call.
+	 *
+	 * @param array|null $plugins Rows, or null to fail.
+	 *
+	 * @return void
+	 */
+	private function fake_directory( $plugins ): void {
+		add_filter(
+			'plugins_api',
+			static function ( $result, $action ) use ( $plugins ) {
+				if ( 'query_plugins' !== $action ) {
+					return $result;
+				}
+
+				if ( null === $plugins ) {
+					return new WP_Error( 'plugins_api_failed', 'The directory is unreachable.' );
+				}
+
+				return (object) array(
+					'plugins' => array_map(
+						static function ( $plugin ) {
+							return (object) $plugin;
+						},
+						$plugins
+					),
+				);
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * A row as the directory returns one.
+	 *
+	 * @param string $slug Plugin slug.
+	 *
+	 * @return array
+	 */
+	private function row( string $slug ): array {
+		return array(
+			'slug'              => $slug,
+			'name'              => ucfirst( $slug ),
+			'short_description' => 'Does a useful thing.',
+			'version'           => '2.0.0',
+			'active_installs'   => 1000,
+			'rating'            => 90,
+			'num_ratings'       => 12,
+			'icons'             => array( '2x' => 'https://ps.w.org/' . $slug . '/assets/icon-256.png' ),
+		);
+	}
+
+	/**
+	 * The endpoint's payload.
+	 *
+	 * @return array
+	 */
+	private function listing(): array {
+		return (array) $this->controller->get_plugins()->get_data();
+	}
+
+	public function test_it_lists_the_authors_plugins(): void {
+		$this->fake_directory( array( $this->row( 'fixture-one' ), $this->row( 'fixture-two' ) ) );
+
+		$data = $this->listing();
+
+		$this->assertCount( 2, $data['plugins'] );
+		$this->assertSame( 'fixture-one', $data['plugins'][0]['slug'] );
+		$this->assertSame( '', $data['error'] );
+
+		// The directory scores out of 100; the screen shows five stars.
+		$this->assertSame( 4.5, $data['plugins'][0]['rating'] );
+	}
+
+	public function test_it_leaves_itself_out(): void {
+		$this->fake_directory(
+			array( $this->row( 'easycommerce-fakerpress' ), $this->row( 'fixture-two' ) )
+		);
+
+		$slugs = wp_list_pluck( $this->listing()['plugins'], 'slug' );
+
+		$this->assertNotContains( 'easycommerce-fakerpress', $slugs );
+		$this->assertContains( 'fixture-two', $slugs );
+	}
+
+	/**
+	 * The directory is asked once and then cached.
+	 *
+	 * A screen that makes a third-party HTTP request on every load hangs for as
+	 * long as WordPress.org is having a bad day.
+	 */
+	public function test_the_directory_is_only_asked_once(): void {
+		$calls = 0;
+
+		add_filter(
+			'plugins_api',
+			function ( $result, $action ) use ( &$calls ) {
+				if ( 'query_plugins' !== $action ) {
+					return $result;
+				}
+
+				++$calls;
+
+				return (object) array( 'plugins' => array( (object) $this->row( 'fixture-two' ) ) );
+			},
+			10,
+			2
+		);
+
+		$this->listing();
+		$this->listing();
+		$this->listing();
+
+		$this->assertSame( 1, $calls );
+	}
+
+	/**
+	 * Install state is read from this site, not from the cached listing.
+	 *
+	 * Caching the two together would leave a plugin reading "not installed" for
+	 * hours after somebody installed it.
+	 */
+	public function test_install_state_is_not_cached_with_the_listing(): void {
+		/*
+		 * A slug that cannot be on disk. `get_plugins()` scans the real plugins
+		 * directory, which on a development machine is the one the site uses — a
+		 * fixture named after something the developer happens to have installed
+		 * would measure their machine rather than this code.
+		 */
+		$this->fake_directory( array( $this->row( 'ecfp-fixture-absent' ) ) );
+
+		$this->assertSame( 'missing', $this->listing()['plugins'][0]['state'] );
+
+		/*
+		 * The site gains the plugin while the listing stays cached. Written into
+		 * the object cache because `get_plugins()` memoises its filesystem scan
+		 * under the `plugins` group and has no filter of its own.
+		 */
+		$cache = wp_cache_get( 'plugins', 'plugins' );
+		$cache = is_array( $cache ) ? $cache : array();
+
+		$cache['']['ecfp-fixture-absent/ecfp-fixture-absent.php'] = array(
+			'Name'    => 'Fixture',
+			'Version' => '1.0.0',
+		);
+
+		wp_cache_set( 'plugins', $cache, 'plugins' );
+
+		$this->assertSame( 'inactive', $this->listing()['plugins'][0]['state'] );
+	}
+
+	/**
+	 * Action links point at core's own screens, carrying core's own nonces.
+	 */
+	public function test_action_links_use_cores_screens_and_nonces(): void {
+		$this->fake_directory( array( $this->row( 'ecfp-fixture-absent' ) ) );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$plugin = $this->listing()['plugins'][0];
+
+		$this->assertStringContainsString( 'update.php', $plugin['action_url'] );
+		$this->assertStringContainsString( 'action=install-plugin', $plugin['action_url'] );
+		$this->assertStringContainsString( '_wpnonce=', $plugin['action_url'] );
+	}
+
+	/**
+	 * Somebody who cannot install plugins is offered no link to do it with.
+	 */
+	public function test_a_user_without_the_capability_gets_no_action_link(): void {
+		$this->fake_directory( array( $this->row( 'ecfp-fixture-absent' ) ) );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertSame( '', $this->listing()['plugins'][0]['action_url'] );
+	}
+
+	/**
+	 * An unreachable directory is a message, not a failed request.
+	 */
+	public function test_an_unreachable_directory_degrades(): void {
+		$this->fake_directory( null );
+
+		$data = $this->listing();
+
+		$this->assertSame( array(), $data['plugins'] );
+		$this->assertNotSame( '', $data['error'] );
+	}
+}


### PR DESCRIPTION
The screen called `api.wordpress.org` from the browser on every paint. That works — but it cannot answer the question somebody opening the screen actually has: *do I already have this one?* It also re-fetched a list that changes about as often as a release, and a directory outage left it spinning with nothing to say.

It now asks this plugin instead.

| | before | after |
|---|---|---|
| directory call | `fetch()` from the browser, every paint | server-side, cached 12h (5 min on failure) |
| install state | not shown | Active / Activate / Install now |
| outage | silent spinner | says the list may be incomplete |

**Install state is worked out per request and never cached with the listing.** The directory's answer changes on their schedule; the site's contents change on the administrator's. Caching them together would leave a plugin reading "not installed" for hours after somebody installed it.

## The buttons are core's, not mine

`update.php?action=install-plugin` and `plugins.php?action=activate`, each built server-side with core's own nonce, and **empty for anybody without the capability** — so what renders is the plugin without a button rather than a button that refuses. Core already carries the filesystem-credentials prompt and the rollback when a plugin fatals on activation. There's a test for the no-capability case.

## Why the controller doesn't extend `Abstracts\Controller`

That base describes something this plugin can fabricate rows of, and a list of somebody's published work isn't one — it needs no generator, no resource type, no label. So it registers its own route, exactly the way `/download-sample` already does in the main class. Not a new pattern; the existing one for non-generator routes.

## One bug fixed on the way

`PluginCard` divided the rating by 20. The server now converts the directory's out-of-100 score before sending it, so dividing again flattened every rating to nought stars.

---

**Verification:** 7 new tests pass; `composer phpcs`, `composer phpstan` and `yarn build` all clean; endpoint checked against the live directory (12 plugins, all three states resolving correctly).

**One caveat worth knowing:** I could not run the full suite meaningfully here. It expects an EasyCommerce store, and my environment is a WooCommerce site with EasyCommerce symlinked in — 79 errors / 97 failures across the generator suites. I verified these are **pre-existing**: `CouponGeneratorTest` gives the identical 16 errors on clean `trunk` with my changes stashed. Nothing in the failures touches this controller. Worth a CI run to confirm.