### PR TITLE
Cross-link the other plugins

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -147,6 +147,24 @@ In your browser's localStorage, not your database. Clearing it has no effect on 
 10. Product Reviews Generator: Target a specific product by ID, configure count, locale, seed, and metadata options.
 11. Locations Generator: Region chip selects, max countries, state and city generation toggles, cities-per-state range, and coordinate generation.
 
+== More from us ==
+
+Other free plugins by the same author, all on WordPress.org.
+
+**Seeding other platforms**
+
+* [StoreSeeder](https://wordpress.org/plugins/storeseeder/) - Realistic test data for WooCommerce and Fluent Cart — a whole shop from a recipe, with one-click cleanup.
+
+**For a store**
+
+* [StoreSheet](https://wordpress.org/plugins/storesheet/) - Sync WooCommerce products, orders and coupons to a Google spreadsheet, one way and in the background.
+* [Warranty Cart](https://wordpress.org/plugins/warranty-cart/) - Sell extended warranties on your products, then handle the claims and renewals that follow.
+
+**For any site**
+
+* [Swift Menu Duplicator](https://wordpress.org/plugins/swift-menu-duplicator/) - Duplicate menus in one click, snapshot revisions, export and import, WP-CLI and REST.
+* [Author Profile Blocks](https://wordpress.org/plugins/author-profile-blocks/) - Author and team profiles as Gutenberg blocks — grid, carousel, list and single.
+
 == Changelog ==
 
 The four most recent releases are listed below. For the complete version history, see the [full changelog on GitHub](https://github.com/mralaminahamed/easycommerce-fakerpress/blob/trunk/CHANGELOG.md).


### PR DESCRIPTION
The listing is the only free channel between these plugins, and nine of the ten live ones had nothing pointing anywhere.

Ordered for this plugin's own reader rather than pasted identically — the first group is what somebody using *this* would plausibly want next. Four to six links, not the whole catalogue: a list of ten reads as noise, three relevant ones read as a recommendation.

Every slug was resolved against the WordPress.org API and confirmed to be one of ours before it was written, and no plugin links to itself.