### PR TITLE
Default svn-cleanup to a dry run

### DIFF
--- a/.github/workflows/svn-cleanup.yml
+++ b/.github/workflows/svn-cleanup.yml
@@ -11,12 +11,15 @@ on:
         description: "Space-separated paths to delete (e.g. src docs README.md)"
         required: true
         default: "src docs"
+      # Defaults to a preview. This workflow deletes from the published SVN with credentials that can
+      # do it, and the dispatch form arrives pre-filled — so the button, pressed without reading, must
+      # not be the destructive one.
       dry_run:
         description: "Dry run — preview deletions without committing"
         required: false
-        default: "false"
+        default: "true"
         type: choice
-        options: ["false", "true"]
+        options: ["true", "false"]
 
 defaults:
   run:


### PR DESCRIPTION
`svn-cleanup.yml` deletes paths from the published SVN with credentials that can do it, and its dispatch form arrives pre-filled: `paths` = `src docs`, `dry_run` = `false`. Open it, press the green button without reading the fields, and `src` and `docs` are deleted from the live plugin and committed.

Now defaults to `"true"`, with `"true"` first in the options list, so the unread path is the safe one. Deleting for real is one deliberate change away, which is the right amount of friction for an irreversible commit to a public repository.

Found while auditing the same workflow set across every repo that publishes to WordPress.org; this is the same change already made in storeseeder. No other behaviour is touched.