### PR TITLE
Aim the listing at the searches it can win

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
-=== EasyCommerce FakerPress ===
+=== EasyCommerce FakerPress – Dummy & Test Data Generator for EasyCommerce ===
 Contributors: mralaminahamed
-Tags: test data, dummy data, sample data, demo content, faker
+Tags: easycommerce, test data, dummy data, demo content, faker
 Requires at least: 6.6
 Tested up to: 7.0
 Requires PHP: 7.4


### PR DESCRIPTION
`easycommerce` (10 competing, **#3**) and `faker` (10, **#5**) already work on name alone. But `dummy` and `test data` — what people type when they do not know this plugin — were nowhere in the title.

- **Title** — `EasyCommerce FakerPress – Dummy & Test Data Generator for EasyCommerce`
- **Tags** — `sample data` → `easycommerce`. The first has 133 competitors led by an unrelated SKU generator; the second is a term this ranks #3 in.

Same change already made in storeseeder, which had the same gap.